### PR TITLE
Update v1.1.1

### DIFF
--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -1,8 +1,13 @@
+[runnable_presets]
+
+"Windows Desktop"="Windows Desktop"
+Linux="Linux"
+Web="Web"
+
 [preset.0]
 
 name="Windows Desktop"
 platform="Windows Desktop"
-runnable=true
 dedicated_server=false
 custom_features=""
 export_filter="all_resources"
@@ -42,8 +47,8 @@ application/modify_resources=true
 application/icon="res://assets/icon.ico"
 application/console_wrapper_icon=""
 application/icon_interpolation=0
-application/file_version="1.0.0.0"
-application/product_version="1.0.0.0"
+application/file_version="1.1.0.0"
+application/product_version="1.1.0.0"
 application/company_name="EBro912"
 application/product_name="OmoriSandbox"
 application/file_description=""
@@ -77,7 +82,6 @@ dotnet/embed_build_outputs=false
 
 name="Linux"
 platform="Linux"
-runnable=true
 dedicated_server=false
 custom_features=""
 export_filter="all_resources"

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -2,7 +2,6 @@
 
 "Windows Desktop"="Windows Desktop"
 Linux="Linux"
-Web="Web"
 
 [preset.0]
 
@@ -47,8 +46,8 @@ application/modify_resources=true
 application/icon="res://assets/icon.ico"
 application/console_wrapper_icon=""
 application/icon_interpolation=0
-application/file_version="1.1.0.0"
-application/product_version="1.1.0.0"
+application/file_version="1.1.1.0"
+application/product_version="1.1.1.0"
 application/company_name="EBro912"
 application/product_name="OmoriSandbox"
 application/file_description=""

--- a/project.godot
+++ b/project.godot
@@ -131,6 +131,7 @@ SpeedUp={
 [rendering]
 
 textures/canvas_textures/default_texture_filter=0
+renderer/rendering_method="gl_compatibility"
 textures/lossless_compression/force_png=true
 textures/default_filters/anisotropic_filtering_level=0
 textures/decals/filter=0

--- a/scenes/enemy_editor_component.tscn
+++ b/scenes/enemy_editor_component.tscn
@@ -5,41 +5,54 @@
 [ext_resource type="StyleBox" uid="uid://dwx8wc4k6lqm" path="res://assets/button_normal.tres" id="3_drgij"]
 [ext_resource type="StyleBox" uid="uid://bo6p8kgoa573n" path="res://assets/button_pressed.tres" id="4_i0156"]
 [ext_resource type="StyleBox" uid="uid://jwq4fr8u18k1" path="res://assets/button_hover.tres" id="5_sv4pq"]
+[ext_resource type="PackedScene" uid="uid://chwhfaladnv86" path="res://scenes/stat_adjustment_editor.tscn" id="6_adjst"]
+[ext_resource type="StyleBox" uid="uid://ividp3svjft4" path="res://assets/tab_selected.tres" id="7_tabsel"]
 
-[node name="EnemyEditorComponent" type="MarginContainer" unique_id=1585099854 node_paths=PackedStringArray("EnemyDropdown", "EmotionDropdown", "XPosBox", "YPosBox", "LayerBox", "FallsOffScreenCheckbox", "GrayscaleOnDefeatCheckbox", "VisibleCheckbox", "RemoveButton")]
+[node name="EnemyEditorComponent" type="TabContainer" unique_id=438065555 node_paths=PackedStringArray("EnemyDropdown", "EmotionDropdown", "XPosBox", "YPosBox", "LayerBox", "FallsOffScreenCheckbox", "GrayscaleOnDefeatCheckbox", "VisibleCheckbox", "RemoveButton", "Tabs", "StatAdjustmentEditor")]
 offset_right = 200.0
-offset_bottom = 300.0
+offset_bottom = 375.0
 mouse_filter = 2
+theme_override_styles/panel = ExtResource("3_drgij")
+theme_override_styles/tab_unselected = ExtResource("3_drgij")
+theme_override_styles/tab_hovered = ExtResource("5_sv4pq")
+theme_override_styles/tab_selected = ExtResource("7_tabsel")
+current_tab = 0
+script = ExtResource("1_hxvew")
+EnemyDropdown = NodePath("Edit/VBoxContainer/Enemy/EnemyDropdown")
+EmotionDropdown = NodePath("Edit/VBoxContainer/Emotion/EmotionDropdown")
+XPosBox = NodePath("Edit/VBoxContainer/XPos/XPosInput")
+YPosBox = NodePath("Edit/VBoxContainer/YPos/YPosInput")
+LayerBox = NodePath("Edit/VBoxContainer/Layer/LayerInput")
+FallsOffScreenCheckbox = NodePath("Edit/VBoxContainer/FallsOffScreen")
+GrayscaleOnDefeatCheckbox = NodePath("Edit/VBoxContainer/GrayTint")
+VisibleCheckbox = NodePath("Edit/VBoxContainer/Visible")
+RemoveButton = NodePath("Edit/VBoxContainer/Remove")
+Tabs = NodePath("")
+StatAdjustmentEditor = NodePath("Adjust Stats")
+
+[node name="Edit" type="MarginContainer" parent="." unique_id=817793439]
+layout_mode = 2
 theme_override_constants/margin_left = 5
 theme_override_constants/margin_top = 2
-theme_override_constants/margin_right = 5
-theme_override_constants/margin_bottom = 2
-script = ExtResource("1_hxvew")
-EnemyDropdown = NodePath("VBoxContainer/Enemy/EnemyDropdown")
-EmotionDropdown = NodePath("VBoxContainer/Emotion/EmotionDropdown")
-XPosBox = NodePath("VBoxContainer/XPos/XPosInput")
-YPosBox = NodePath("VBoxContainer/YPos/YPosInput")
-LayerBox = NodePath("VBoxContainer/Layer/LayerInput")
-FallsOffScreenCheckbox = NodePath("VBoxContainer/FallsOffScreen")
-GrayscaleOnDefeatCheckbox = NodePath("VBoxContainer/GrayTint")
-VisibleCheckbox = NodePath("VBoxContainer/Visible")
-RemoveButton = NodePath("VBoxContainer/Remove")
+theme_override_constants/margin_right = 2
+theme_override_constants/margin_bottom = 5
+metadata/_tab_index = 0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=419578643]
+[node name="VBoxContainer" type="VBoxContainer" parent="Edit" unique_id=419578643]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="Enemy" type="HBoxContainer" parent="VBoxContainer" unique_id=125233606]
+[node name="Enemy" type="HBoxContainer" parent="Edit/VBoxContainer" unique_id=125233606]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/Enemy" unique_id=1866988893]
+[node name="Label" type="Label" parent="Edit/VBoxContainer/Enemy" unique_id=1866988893]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("2_qooje")
 theme_override_font_sizes/font_size = 20
 text = "Enemy"
 
-[node name="EnemyDropdown" type="OptionButton" parent="VBoxContainer/Enemy" unique_id=1137956997]
+[node name="EnemyDropdown" type="OptionButton" parent="Edit/VBoxContainer/Enemy" unique_id=1137956997]
 layout_mode = 2
 mouse_filter = 1
 theme_override_fonts/font = ExtResource("2_qooje")
@@ -49,17 +62,17 @@ theme_override_styles/pressed = ExtResource("4_i0156")
 theme_override_styles/hover = ExtResource("5_sv4pq")
 allow_reselect = true
 
-[node name="Emotion" type="HBoxContainer" parent="VBoxContainer" unique_id=76289680]
+[node name="Emotion" type="HBoxContainer" parent="Edit/VBoxContainer" unique_id=76289680]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/Emotion" unique_id=1555249491]
+[node name="Label" type="Label" parent="Edit/VBoxContainer/Emotion" unique_id=1555249491]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("2_qooje")
 theme_override_font_sizes/font_size = 20
 text = "Emotion"
 
-[node name="EmotionDropdown" type="OptionButton" parent="VBoxContainer/Emotion" unique_id=514070426]
+[node name="EmotionDropdown" type="OptionButton" parent="Edit/VBoxContainer/Emotion" unique_id=514070426]
 layout_mode = 2
 mouse_filter = 1
 theme_override_fonts/font = ExtResource("2_qooje")
@@ -69,72 +82,72 @@ theme_override_styles/pressed = ExtResource("4_i0156")
 theme_override_styles/hover = ExtResource("5_sv4pq")
 allow_reselect = true
 
-[node name="XPos" type="HBoxContainer" parent="VBoxContainer" unique_id=680841036]
+[node name="XPos" type="HBoxContainer" parent="Edit/VBoxContainer" unique_id=680841036]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/XPos" unique_id=1028832870]
+[node name="Label" type="Label" parent="Edit/VBoxContainer/XPos" unique_id=1028832870]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("2_qooje")
 theme_override_font_sizes/font_size = 20
 text = "X Pos"
 
-[node name="XPosInput" type="SpinBox" parent="VBoxContainer/XPos" unique_id=1270280068]
+[node name="XPosInput" type="SpinBox" parent="Edit/VBoxContainer/XPos" unique_id=1270280068]
 layout_mode = 2
 max_value = 640.0
 value = 320.0
 
-[node name="YPos" type="HBoxContainer" parent="VBoxContainer" unique_id=689938597]
+[node name="YPos" type="HBoxContainer" parent="Edit/VBoxContainer" unique_id=689938597]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/YPos" unique_id=931113728]
+[node name="Label" type="Label" parent="Edit/VBoxContainer/YPos" unique_id=931113728]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("2_qooje")
 theme_override_font_sizes/font_size = 20
 text = "Y Pos"
 
-[node name="YPosInput" type="SpinBox" parent="VBoxContainer/YPos" unique_id=1997410742]
+[node name="YPosInput" type="SpinBox" parent="Edit/VBoxContainer/YPos" unique_id=1997410742]
 layout_mode = 2
 max_value = 480.0
 value = 240.0
 
-[node name="Layer" type="HBoxContainer" parent="VBoxContainer" unique_id=1705452760]
+[node name="Layer" type="HBoxContainer" parent="Edit/VBoxContainer" unique_id=1705452760]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/Layer" unique_id=1891309881]
+[node name="Label" type="Label" parent="Edit/VBoxContainer/Layer" unique_id=1891309881]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("2_qooje")
 theme_override_font_sizes/font_size = 20
 text = "Layer"
 
-[node name="LayerInput" type="SpinBox" parent="VBoxContainer/Layer" unique_id=104157753]
+[node name="LayerInput" type="SpinBox" parent="Edit/VBoxContainer/Layer" unique_id=104157753]
 layout_mode = 2
 max_value = 50.0
 rounded = true
 
-[node name="LayerNote" type="Label" parent="VBoxContainer" unique_id=1223782191]
+[node name="LayerNote" type="Label" parent="Edit/VBoxContainer" unique_id=1223782191]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("2_qooje")
 theme_override_font_sizes/font_size = 18
 text = "Note: Layer 0 is the top layer"
 
-[node name="FallsOffScreen" type="CheckBox" parent="VBoxContainer" unique_id=1804147080]
+[node name="FallsOffScreen" type="CheckBox" parent="Edit/VBoxContainer" unique_id=1804147080]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("2_qooje")
 theme_override_font_sizes/font_size = 20
 theme_override_colors/checkbox_unchecked_color = Color(3.2944162, 3.2944162, 3.2944162, 1)
 text = "Falls Off Screen"
 
-[node name="GrayTint" type="CheckBox" parent="VBoxContainer" unique_id=1275036391]
+[node name="GrayTint" type="CheckBox" parent="Edit/VBoxContainer" unique_id=1275036391]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("2_qooje")
 theme_override_font_sizes/font_size = 20
 theme_override_colors/checkbox_unchecked_color = Color(3.2944162, 3.2944162, 3.2944162, 1)
 text = "Grayscale On Defeat"
 
-[node name="Visible" type="CheckBox" parent="VBoxContainer" unique_id=1186235395]
+[node name="Visible" type="CheckBox" parent="Edit/VBoxContainer" unique_id=1186235395]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("2_qooje")
 theme_override_font_sizes/font_size = 20
@@ -142,7 +155,7 @@ theme_override_colors/checkbox_unchecked_color = Color(3.2944162, 3.2944162, 3.2
 button_pressed = true
 text = "Visible (Editor Only)"
 
-[node name="Remove" type="Button" parent="VBoxContainer" unique_id=382092398]
+[node name="Remove" type="Button" parent="Edit/VBoxContainer" unique_id=382092398]
 layout_mode = 2
 mouse_filter = 1
 theme_override_fonts/font = ExtResource("2_qooje")
@@ -151,3 +164,8 @@ theme_override_styles/normal = ExtResource("3_drgij")
 theme_override_styles/pressed = ExtResource("4_i0156")
 theme_override_styles/hover = ExtResource("5_sv4pq")
 text = "Remove"
+
+[node name="Adjust Stats" parent="." unique_id=862740600 instance=ExtResource("6_adjst")]
+visible = false
+layout_mode = 2
+metadata/_tab_index = 1

--- a/scenes/enemy_infobox_moreinfo.tscn
+++ b/scenes/enemy_infobox_moreinfo.tscn
@@ -14,7 +14,7 @@
 [ext_resource type="Texture2D" uid="uid://csbpqs4le5y8m" path="res://assets/system/emotion_box.png" id="11_itdm3"]
 [ext_resource type="PackedScene" uid="uid://bq6cqi4jmrqwe" path="res://scenes/StateAnimatorComponent.tscn" id="13_m53md"]
 
-[node name="AboveHead" type="Control" unique_id=1300360389 node_paths=PackedStringArray("HPLabel", "JuiceBar", "JuiceLabel", "ATKLabel", "SPDLabel", "DEFLabel", "LCKLabel", "HITLabel", "Animator", "Infobox", "NameLabel", "HPBar", "StateIcons")]
+[node name="AboveHead" type="Control" unique_id=1300360389 node_paths=PackedStringArray("HPLabel", "JuiceBar", "JuiceLabel", "ATKLabel", "SPDLabel", "EVALabel", "DEFLabel", "LCKLabel", "HITLabel", "Animator", "Infobox", "NameLabel", "HPBar", "StateIcons")]
 z_index = 100
 z_as_relative = false
 layout_mode = 3
@@ -27,6 +27,7 @@ JuiceBar = NodePath("Infobox/Juice")
 JuiceLabel = NodePath("Infobox/Juice/JuiceLabel")
 ATKLabel = NodePath("Infobox/ATKLabel")
 SPDLabel = NodePath("Infobox/SPDLabel")
+EVALabel = NodePath("Infobox/EVALabel")
 DEFLabel = NodePath("Infobox/DEFLabel")
 LCKLabel = NodePath("Infobox/LCKLabel")
 HITLabel = NodePath("Infobox/HITLabel")
@@ -156,9 +157,9 @@ anchors_preset = 4
 anchor_top = 0.5
 anchor_bottom = 0.5
 offset_left = 4.0
-offset_top = -6.0
+offset_top = -11.0
 offset_right = 93.5
-offset_bottom = 13.0
+offset_bottom = 8.0
 grow_vertical = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
@@ -172,15 +173,31 @@ anchors_preset = 4
 anchor_top = 0.5
 anchor_bottom = 0.5
 offset_left = 4.0
-offset_top = 9.0
+offset_top = 2.0
 offset_right = 93.5
-offset_bottom = 28.0
+offset_bottom = 21.0
 grow_vertical = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
 theme_override_fonts/font = ExtResource("2_wl8cr")
 theme_override_font_sizes/font_size = 17
 text = "SPD: 0"
+
+[node name="EVALabel" type="Label" parent="Infobox" unique_id=1770004505]
+layout_mode = 1
+anchors_preset = 4
+anchor_top = 0.5
+anchor_bottom = 0.5
+offset_left = 4.0
+offset_top = 16.0
+offset_right = 93.5
+offset_bottom = 35.0
+grow_vertical = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 3
+theme_override_fonts/font = ExtResource("2_wl8cr")
+theme_override_font_sizes/font_size = 17
+text = "EVA: 0"
 
 [node name="DEFLabel" type="Label" parent="Infobox" unique_id=1810615813]
 layout_mode = 1

--- a/scenes/enemy_infobox_moreinfo.tscn
+++ b/scenes/enemy_infobox_moreinfo.tscn
@@ -14,7 +14,7 @@
 [ext_resource type="Texture2D" uid="uid://csbpqs4le5y8m" path="res://assets/system/emotion_box.png" id="11_itdm3"]
 [ext_resource type="PackedScene" uid="uid://bq6cqi4jmrqwe" path="res://scenes/StateAnimatorComponent.tscn" id="13_m53md"]
 
-[node name="AboveHead" type="Control" unique_id=1300360389 node_paths=PackedStringArray("HPLabel", "JuiceBar", "JuiceLabel", "ATKLabel", "SPDLabel", "EVALabel", "DEFLabel", "LCKLabel", "HITLabel", "Animator", "Infobox", "NameLabel", "HPBar", "StateIcons")]
+[node name="AboveHead" type="Control" unique_id=1300360389 node_paths=PackedStringArray("HPLabel", "JuiceBar", "JuiceLabel", "ATKLabel", "SPDLabel", "DEFLabel", "LCKLabel", "HITLabel", "EVALabel", "Animator", "Infobox", "NameLabel", "HPBar", "StateIcons")]
 z_index = 100
 z_as_relative = false
 layout_mode = 3
@@ -27,10 +27,10 @@ JuiceBar = NodePath("Infobox/Juice")
 JuiceLabel = NodePath("Infobox/Juice/JuiceLabel")
 ATKLabel = NodePath("Infobox/ATKLabel")
 SPDLabel = NodePath("Infobox/SPDLabel")
-EVALabel = NodePath("Infobox/EVALabel")
 DEFLabel = NodePath("Infobox/DEFLabel")
 LCKLabel = NodePath("Infobox/LCKLabel")
 HITLabel = NodePath("Infobox/HITLabel")
+EVALabel = NodePath("Infobox/EVALabel")
 Animator = NodePath("StateAnimatorComponent")
 Infobox = NodePath("Infobox")
 NameLabel = NodePath("Infobox/Name")
@@ -156,9 +156,9 @@ layout_mode = 1
 anchors_preset = 4
 anchor_top = 0.5
 anchor_bottom = 0.5
-offset_left = 4.0
+offset_left = 6.0
 offset_top = -11.0
-offset_right = 93.5
+offset_right = 95.5
 offset_bottom = 8.0
 grow_vertical = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
@@ -172,9 +172,9 @@ layout_mode = 1
 anchors_preset = 4
 anchor_top = 0.5
 anchor_bottom = 0.5
-offset_left = 4.0
+offset_left = 6.0
 offset_top = 2.0
-offset_right = 93.5
+offset_right = 95.5
 offset_bottom = 21.0
 grow_vertical = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
@@ -185,19 +185,23 @@ text = "SPD: 0"
 
 [node name="EVALabel" type="Label" parent="Infobox" unique_id=1770004505]
 layout_mode = 1
-anchors_preset = 4
+anchors_preset = 6
+anchor_left = 1.0
 anchor_top = 0.5
+anchor_right = 1.0
 anchor_bottom = 0.5
-offset_left = 4.0
+offset_left = -95.0
 offset_top = 16.0
-offset_right = 93.5
+offset_right = -5.5
 offset_bottom = 35.0
+grow_horizontal = 0
 grow_vertical = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
 theme_override_fonts/font = ExtResource("2_wl8cr")
 theme_override_font_sizes/font_size = 17
 text = "EVA: 0"
+horizontal_alignment = 2
 
 [node name="DEFLabel" type="Label" parent="Infobox" unique_id=1810615813]
 layout_mode = 1
@@ -206,9 +210,9 @@ anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
 anchor_bottom = 0.5
-offset_left = -93.0
+offset_left = -95.0
 offset_top = -11.0
-offset_right = -3.5
+offset_right = -5.5
 offset_bottom = 8.0
 grow_horizontal = 0
 grow_vertical = 2
@@ -226,9 +230,9 @@ anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
 anchor_bottom = 0.5
-offset_left = -93.0
+offset_left = -95.0
 offset_top = 2.0
-offset_right = -3.5
+offset_right = -5.5
 offset_bottom = 21.0
 grow_horizontal = 0
 grow_vertical = 2
@@ -241,23 +245,19 @@ horizontal_alignment = 2
 
 [node name="HITLabel" type="Label" parent="Infobox" unique_id=1856701847]
 layout_mode = 1
-anchors_preset = 6
-anchor_left = 1.0
+anchors_preset = 4
 anchor_top = 0.5
-anchor_right = 1.0
 anchor_bottom = 0.5
-offset_left = -93.0
+offset_left = 6.0
 offset_top = 16.0
-offset_right = -3.5
+offset_right = 95.5
 offset_bottom = 35.0
-grow_horizontal = 0
 grow_vertical = 2
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 3
 theme_override_fonts/font = ExtResource("2_wl8cr")
 theme_override_font_sizes/font_size = 17
 text = "HIT: 0"
-horizontal_alignment = 2
 
 [node name="State" type="Sprite2D" parent="Infobox" unique_id=89515979]
 position = Vector2(0, 31)

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -203,7 +203,6 @@ text = "Restart Queued..."
 [node name="Battleback" type="TextureRect" parent="BattleCanvas/UI/BattlebackRoot" unique_id=38412468]
 z_index = -100
 use_parent_material = true
-layout_mode = 0
 offset_left = -640.0
 offset_right = 1280.0
 offset_bottom = 480.0
@@ -700,7 +699,7 @@ script = ExtResource("44_nvyfr")
 [node name="Cursor" parent="BattleCanvas/UI/SkillMenu" unique_id=504568155 instance=ExtResource("24_qkpxi")]
 visible = true
 
-[node name="PageUp" type="Sprite2D" parent="BattleCanvas/UI/SkillMenu"]
+[node name="PageUp" type="Sprite2D" parent="BattleCanvas/UI/SkillMenu" unique_id=397386569]
 visible = false
 position = Vector2(350, 35)
 texture = ExtResource("26_kmb1v")
@@ -708,7 +707,7 @@ flip_v = true
 region_enabled = true
 region_rect = Rect2(151, 111, 10, 5)
 
-[node name="PageDown" type="Sprite2D" parent="BattleCanvas/UI/SkillMenu"]
+[node name="PageDown" type="Sprite2D" parent="BattleCanvas/UI/SkillMenu" unique_id=2061373747]
 visible = false
 position = Vector2(350, 90)
 texture = ExtResource("26_kmb1v")

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -323,7 +323,7 @@ centered = false
 
 [node name="Party" type="Node" parent="BattleCanvas/UI" unique_id=888063636]
 
-[node name="BattleLog" type="TextureRect" parent="BattleCanvas/UI" unique_id=1410267183 node_paths=PackedStringArray("ImmediateLabel", "Icon")]
+[node name="BattleLog" type="TextureRect" parent="BattleCanvas/UI" unique_id=1410267183 node_paths=PackedStringArray("ImmediateLabel", "Icon", "LineContainer")]
 visible = false
 z_index = -1
 layout_mode = 1
@@ -340,6 +340,7 @@ LogLine = ExtResource("10_trceg")
 ImmediateLabel = NodePath("Immediate")
 Font = ExtResource("10_choun")
 Icon = NodePath("Icon")
+LineContainer = NodePath("Lines")
 metadata/_edit_use_anchors_ = true
 
 [node name="Immediate" type="RichTextLabel" parent="BattleCanvas/UI/BattleLog" unique_id=955638223]
@@ -366,6 +367,17 @@ position = Vector2(308.5, 40.882072)
 scale = Vector2(0.75, 0.75)
 region_enabled = true
 region_rect = Rect2(108, 0, 108, 108)
+
+[node name="Lines" type="Control" parent="BattleCanvas/UI/BattleLog" unique_id=1770004507]
+clip_contents = true
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_bottom = -6.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
 
 [node name="DialogueBox" type="Node2D" parent="BattleCanvas/UI" unique_id=456223279 node_paths=PackedStringArray("Text", "Box", "SpeakerSprite", "Cursor", "ChoiceBox", "ChoiceTextParent")]
 visible = false
@@ -1034,3 +1046,5 @@ theme_override_styles/normal = ExtResource("37_c6pm6")
 theme_override_styles/pressed = ExtResource("38_5he1u")
 theme_override_styles/hover = ExtResource("39_5poiv")
 text = "Return to Menu"
+
+[node name="Sprite2D" type="Sprite2D" parent="." unique_id=1656095367]

--- a/scenes/main_menu.tscn
+++ b/scenes/main_menu.tscn
@@ -57,7 +57,7 @@ TitlePresetDropdown = NodePath("../Main/MainControls/PresetSelector/PresetDropdo
 StageSelectorParent = NodePath("../Main/MainControls/StageSelector")
 StageSelectorSpinBox = NodePath("../Main/MainControls/StageSelector/StageSpinBox")
 
-[node name="EditorManager" type="Node" parent="." unique_id=1425104684 node_paths=PackedStringArray("BGMPreview", "BattlebackPreview", "AddActorControls", "AddEnemyControl", "ActorTabs", "EnemyTabs", "BattlebackBGMEditor", "StartingEnergySlider", "StartingEnergyValue", "FollowupTierSlider", "FollowupTierValue", "DisableDialogue", "DisableDamageNumbers", "AddItemButton", "ItemContainer", "SearchInput", "SearchButton", "Results", "SavePresetButton", "PresetInput", "LoadPresetButton", "DeletePresetButton", "PresetDropdown", "ResetButton", "ReturnButton", "PresetFolderButton", "AddStageButton", "DuplicateStageButton", "RemoveStageButton", "MoveStageLeftButton", "MoveStageRightButton", "ImportPresetDropdown", "ImportButton", "StageTabs", "MainTabs")]
+[node name="EditorManager" type="Node" parent="." unique_id=1425104684 node_paths=PackedStringArray("BGMPreview", "BattlebackPreview", "AddActorControls", "AddEnemyControl", "ActorTabs", "EnemyTabs", "BattlebackBGMEditor", "StartingEnergySlider", "StartingEnergyValue", "FollowupTierSlider", "FollowupTierValue", "DisableDialogue", "DisableDamageNumbers", "CombinedBuffsDebuffs", "AddItemButton", "ItemContainer", "SearchInput", "SearchButton", "Results", "SavePresetButton", "PresetInput", "LoadPresetButton", "DeletePresetButton", "PresetDropdown", "ResetButton", "ReturnButton", "PresetFolderButton", "AddStageButton", "DuplicateStageButton", "RemoveStageButton", "MoveStageLeftButton", "MoveStageRightButton", "ImportPresetDropdown", "ImportButton", "StageTabs", "MainTabs")]
 script = ExtResource("12_7b55j")
 BGMPreview = NodePath("../BGMPreview")
 BattlebackPreview = NodePath("../Editor/BattlebackPreview")
@@ -76,6 +76,7 @@ FollowupTierSlider = NodePath("../Editor/SettingsTabs/Settings/VBoxContainer/Fol
 FollowupTierValue = NodePath("../Editor/SettingsTabs/Settings/VBoxContainer/FollowupTier/Label2")
 DisableDialogue = NodePath("../Editor/SettingsTabs/Settings/VBoxContainer/OtherSettings/DisableDialogue")
 DisableDamageNumbers = NodePath("../Editor/SettingsTabs/Settings/VBoxContainer/OtherSettings/DisableDamageNumbers")
+CombinedBuffsDebuffs = NodePath("../Editor/SettingsTabs/Settings/VBoxContainer/OtherSettings/CombinedBuffsDebuffs")
 AddItemButton = NodePath("../Editor/SettingsTabs/Items/VBoxContainer/AddItemButton")
 ItemContainer = NodePath("../Editor/SettingsTabs/Items/VBoxContainer/ScrollContainer/ItemsContainer")
 SearchInput = NodePath("../Editor/SettingsTabs/Tools/Skill Search/VBoxContainer/HBoxContainer/SearchInput")
@@ -1455,6 +1456,13 @@ theme_override_fonts/font = ExtResource("2_ekxnf")
 theme_override_font_sizes/font_size = 20
 theme_override_colors/checkbox_unchecked_color = Color(3.2944162, 3.2944162, 3.2944162, 1)
 text = "Disable Damage Numbers"
+
+[node name="CombinedBuffsDebuffs" type="CheckBox" parent="Editor/SettingsTabs/Settings/VBoxContainer/OtherSettings" unique_id=1539284771]
+layout_mode = 2
+theme_override_fonts/font = ExtResource("2_ekxnf")
+theme_override_font_sizes/font_size = 20
+theme_override_colors/checkbox_unchecked_color = Color(3.2944162, 3.2944162, 3.2944162, 1)
+text = "Combined Buffs/Debuffs"
 
 [node name="Save" type="HBoxContainer" parent="Editor/SettingsTabs/Settings/VBoxContainer" unique_id=1068584530]
 layout_mode = 2

--- a/scenes/main_menu.tscn
+++ b/scenes/main_menu.tscn
@@ -371,7 +371,7 @@ theme_override_styles/hover = ExtResource("12_1ajci")
 text = "Quit
 "
 
-[node name="Settings" type="Panel" parent="Main" unique_id=1298067288 node_paths=PackedStringArray("Logo", "OmoriFace", "MasterSlider", "BGMSlider", "SFXSlider", "TestSFXButton", "FullscreenCheckbox", "BattlelogSpeedSlider", "ActionDelaySlider", "ShowFPSCheckbox", "LogDebugCheckbox", "PreventRunCheckbox", "DisableDamageLimitCheckbox", "DisableStatLimitCheckbox", "ShowMoreInfoCheckbox", "ShowStateIconsCheckbox", "EnemySelectionWrappingCheckbox", "SelectionHoldTimeSlider", "SelectionHoldTimeLabel", "SelectionChangeSpeedSlider", "SelectionChangeSpeedLabel", "UseConsoleSpdCheckbox", "UseConsoleDefCheckbox", "InfiniteBuffsDebuffsCheckbox", "VertigoUsesAtkCheckbox", "ToysUseEmotionDamageCheckbox", "SpaceExHusbandReleaseEnergyCheckbox", "EnableDebugDamageCheckbox", "CombinedAccuracyCheckbox", "RestartHoldTimeSlider", "RestartHoldTimeLabel", "SpeedUpSlider", "SpeedUpLabel", "KeybindGrid", "ResetKeybindsButton", "BackButton", "MainControls")]
+[node name="Settings" type="Panel" parent="Main" unique_id=1298067288 node_paths=PackedStringArray("Logo", "OmoriFace", "MasterSlider", "BGMSlider", "SFXSlider", "TestSFXButton", "FullscreenCheckbox", "BattlelogSpeedSlider", "ActionDelaySlider", "DialogueSpeedSlider", "DialogueSpeedLabel", "ShowFPSCheckbox", "LogDebugCheckbox", "PreventRunCheckbox", "DisableDamageLimitCheckbox", "DisableStatLimitCheckbox", "ShowMoreInfoCheckbox", "ShowStateIconsCheckbox", "EnemySelectionWrappingCheckbox", "SelectionHoldTimeSlider", "SelectionHoldTimeLabel", "SelectionChangeSpeedSlider", "SelectionChangeSpeedLabel", "UseConsoleSpdCheckbox", "UseConsoleDefCheckbox", "InfiniteBuffsDebuffsCheckbox", "VertigoUsesAtkCheckbox", "ToysUseEmotionDamageCheckbox", "SpaceExHusbandReleaseEnergyCheckbox", "EnableDebugDamageCheckbox", "CombinedAccuracyCheckbox", "RestartHoldTimeSlider", "RestartHoldTimeLabel", "SpeedUpSlider", "SpeedUpLabel", "KeybindGrid", "ResetKeybindsButton", "BackButton", "MainControls")]
 visible = false
 anchors_preset = 7
 anchor_left = 0.5
@@ -395,6 +395,8 @@ TestSFXButton = NodePath("ScrollContainer/VBoxContainer/TestSFX")
 FullscreenCheckbox = NodePath("ScrollContainer/VBoxContainer/Fullscreen")
 BattlelogSpeedSlider = NodePath("ScrollContainer/VBoxContainer/BattlelogSpeedSlider/BattlelogSpeedSlider")
 ActionDelaySlider = NodePath("ScrollContainer/VBoxContainer/ActionDelaySlider/DelaySlider")
+DialogueSpeedSlider = NodePath("ScrollContainer/VBoxContainer/DialogueSpeedSlider/HSlider")
+DialogueSpeedLabel = NodePath("ScrollContainer/VBoxContainer/DialogueSpeedSlider/Label")
 ShowFPSCheckbox = NodePath("ScrollContainer/VBoxContainer/ShowFPS")
 LogDebugCheckbox = NodePath("ScrollContainer/VBoxContainer/LogDebug")
 PreventRunCheckbox = NodePath("ScrollContainer/VBoxContainer/RequireTwoRunInputs")
@@ -641,6 +643,40 @@ size_flags_vertical = 0
 theme_override_fonts/font = ExtResource("2_ekxnf")
 theme_override_font_sizes/font_size = 20
 text = "Short"
+
+[node name="DialogueSpeed" type="Label" parent="Main/Settings/ScrollContainer/VBoxContainer" unique_id=1770004508]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 0
+theme_override_fonts/font = ExtResource("2_ekxnf")
+theme_override_font_sizes/font_size = 20
+text = "Dialogue Speed"
+
+[node name="DialogueSpeedSlider" type="HBoxContainer" parent="Main/Settings/ScrollContainer/VBoxContainer" unique_id=1770004509]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+alignment = 1
+
+[node name="HSlider" type="HSlider" parent="Main/Settings/ScrollContainer/VBoxContainer/DialogueSpeedSlider" unique_id=1770004510]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+tooltip_text = "How fast dialogue text types out;
+the maximum value displays text instantly"
+min_value = 0.25
+max_value = 5.0
+step = 0.25
+value = 1.0
+scrollable = false
+
+[node name="Label" type="Label" parent="Main/Settings/ScrollContainer/VBoxContainer/DialogueSpeedSlider" unique_id=1770004511]
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_fonts/font = ExtResource("2_ekxnf")
+theme_override_font_sizes/font_size = 20
+text = "1.00x"
 
 [node name="ShowFPS" type="CheckBox" parent="Main/Settings/ScrollContainer/VBoxContainer" unique_id=1098298253]
 layout_mode = 2

--- a/scenes/main_menu.tscn
+++ b/scenes/main_menu.tscn
@@ -371,7 +371,7 @@ theme_override_styles/hover = ExtResource("12_1ajci")
 text = "Quit
 "
 
-[node name="Settings" type="Panel" parent="Main" unique_id=1298067288 node_paths=PackedStringArray("Logo", "OmoriFace", "MasterSlider", "BGMSlider", "SFXSlider", "TestSFXButton", "FullscreenCheckbox", "BattlelogSpeedSlider", "ActionDelaySlider", "ShowFPSCheckbox", "LogDebugCheckbox", "PreventRunCheckbox", "DisableDamageLimitCheckbox", "DisableStatLimitCheckbox", "ShowMoreInfoCheckbox", "ShowStateIconsCheckbox", "EnemySelectionWrappingCheckbox", "SelectionHoldTimeSlider", "SelectionHoldTimeLabel", "SelectionChangeSpeedSlider", "SelectionChangeSpeedLabel", "UseConsoleSpdCheckbox", "UseConsoleDefCheckbox", "InfiniteBuffsDebuffsCheckbox", "VertigoUsesAtkCheckbox", "ToysUseEmotionDamageCheckbox", "SpaceExHusbandReleaseEnergyCheckbox", "EnableDebugDamageCheckbox", "RestartHoldTimeSlider", "RestartHoldTimeLabel", "SpeedUpSlider", "SpeedUpLabel", "KeybindGrid", "ResetKeybindsButton", "BackButton", "MainControls")]
+[node name="Settings" type="Panel" parent="Main" unique_id=1298067288 node_paths=PackedStringArray("Logo", "OmoriFace", "MasterSlider", "BGMSlider", "SFXSlider", "TestSFXButton", "FullscreenCheckbox", "BattlelogSpeedSlider", "ActionDelaySlider", "ShowFPSCheckbox", "LogDebugCheckbox", "PreventRunCheckbox", "DisableDamageLimitCheckbox", "DisableStatLimitCheckbox", "ShowMoreInfoCheckbox", "ShowStateIconsCheckbox", "EnemySelectionWrappingCheckbox", "SelectionHoldTimeSlider", "SelectionHoldTimeLabel", "SelectionChangeSpeedSlider", "SelectionChangeSpeedLabel", "UseConsoleSpdCheckbox", "UseConsoleDefCheckbox", "InfiniteBuffsDebuffsCheckbox", "VertigoUsesAtkCheckbox", "ToysUseEmotionDamageCheckbox", "SpaceExHusbandReleaseEnergyCheckbox", "EnableDebugDamageCheckbox", "CombinedAccuracyCheckbox", "RestartHoldTimeSlider", "RestartHoldTimeLabel", "SpeedUpSlider", "SpeedUpLabel", "KeybindGrid", "ResetKeybindsButton", "BackButton", "MainControls")]
 visible = false
 anchors_preset = 7
 anchor_left = 0.5
@@ -414,6 +414,7 @@ VertigoUsesAtkCheckbox = NodePath("ScrollContainer/VBoxContainer/VertigoUsesAtk"
 ToysUseEmotionDamageCheckbox = NodePath("ScrollContainer/VBoxContainer/ToysUseEmotionDamage")
 SpaceExHusbandReleaseEnergyCheckbox = NodePath("ScrollContainer/VBoxContainer/SpaceExHusbandReleaseEnergy")
 EnableDebugDamageCheckbox = NodePath("ScrollContainer/VBoxContainer/EnableDebugDamage")
+CombinedAccuracyCheckbox = NodePath("ScrollContainer/VBoxContainer/CombinedAccuracy")
 RestartHoldTimeSlider = NodePath("ScrollContainer/VBoxContainer/RestartDelaySlider/HSlider")
 RestartHoldTimeLabel = NodePath("ScrollContainer/VBoxContainer/RestartDelaySlider/Label")
 SpeedUpSlider = NodePath("ScrollContainer/VBoxContainer/SpeedUpSlider/HSlider")
@@ -815,6 +816,16 @@ theme_override_fonts/font = ExtResource("2_ekxnf")
 theme_override_font_sizes/font_size = 20
 theme_override_colors/checkbox_unchecked_color = Color(3.2944162, 3.2944162, 3.2944162, 1)
 text = "Vertigo Uses ATK Stat"
+
+[node name="CombinedAccuracy" type="CheckBox" parent="Main/Settings/ScrollContainer/VBoxContainer" unique_id=1657483920]
+layout_mode = 2
+size_flags_horizontal = 4
+tooltip_text = "Accuracy uses a single roll of (user.HIT - target.EVA)
+instead of separate hit and evasion rolls"
+theme_override_fonts/font = ExtResource("2_ekxnf")
+theme_override_font_sizes/font_size = 20
+theme_override_colors/checkbox_unchecked_color = Color(3.2944162, 3.2944162, 3.2944162, 1)
+text = "Combined Accuracy Formula"
 
 [node name="ToysUseEmotionDamage" type="CheckBox" parent="Main/Settings/ScrollContainer/VBoxContainer" unique_id=1655251340]
 layout_mode = 2
@@ -1496,6 +1507,7 @@ theme_override_font_sizes/font_size = 20
 theme_override_styles/normal = ExtResource("10_1ajci")
 theme_override_styles/pressed = ExtResource("11_7b55j")
 theme_override_styles/hover = ExtResource("12_1ajci")
+fit_to_longest_item = false
 
 [node name="Load" type="Button" parent="Editor/SettingsTabs/Settings/VBoxContainer/Load" unique_id=1960389968]
 layout_mode = 2

--- a/scenes/party_member.tscn
+++ b/scenes/party_member.tscn
@@ -104,6 +104,7 @@ text = "0/0"
 label_settings = SubResource("LabelSettings_3r6nr")
 horizontal_alignment = 2
 vertical_alignment = 1
+text_overrun_behavior = 3
 
 [node name="JuiceLabel" type="Label" parent="Battlecard" unique_id=486899302]
 layout_mode = 0
@@ -114,6 +115,7 @@ offset_bottom = 160.35
 text = "0/0"
 label_settings = SubResource("LabelSettings_3r6nr")
 horizontal_alignment = 2
+text_overrun_behavior = 3
 
 [node name="StateAnimatorComponent" parent="Battlecard" unique_id=703804128 node_paths=PackedStringArray("StateSprite", "FaceStateSprite") instance=ExtResource("5_xyj2y")]
 StateSprite = NodePath("../State")

--- a/scenes/stat_adjustment_editor.tscn
+++ b/scenes/stat_adjustment_editor.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="StyleBox" uid="uid://bo6p8kgoa573n" path="res://assets/button_pressed.tres" id="3_35yh7"]
 [ext_resource type="StyleBox" uid="uid://jwq4fr8u18k1" path="res://assets/button_hover.tres" id="4_okig5"]
 
-[node name="StatAdjustmentEditor" type="MarginContainer" unique_id=862740600 node_paths=PackedStringArray("PresetDropdown", "AddButton", "ResetButton", "HeartBox", "JuiceBox", "ATKBox", "DEFBox", "SPDBox", "LCKBox", "HITBox", "HeartLabel", "JuiceLabel", "ATKLabel", "DEFLabel", "SPDLabel", "LCKLabel", "HITLabel")]
+[node name="StatAdjustmentEditor" type="MarginContainer" unique_id=862740600 node_paths=PackedStringArray("PresetDropdown", "AddButton", "ResetButton", "HeartBox", "JuiceBox", "ATKBox", "DEFBox", "SPDBox", "LCKBox", "HITBox", "EVABox", "HeartLabel", "JuiceLabel", "ATKLabel", "DEFLabel", "SPDLabel", "LCKLabel", "HITLabel", "EVALabel")]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -29,6 +29,7 @@ DEFBox = NodePath("VBoxContainer/StatAdjuster/DEF/Input")
 SPDBox = NodePath("VBoxContainer/StatAdjuster/SPD/Input")
 LCKBox = NodePath("VBoxContainer/StatAdjuster/LCK/Input")
 HITBox = NodePath("VBoxContainer/StatAdjuster/HIT/Input")
+EVABox = NodePath("VBoxContainer/StatAdjuster/EVA/Input")
 HeartLabel = NodePath("VBoxContainer/BaseStats/Heart")
 JuiceLabel = NodePath("VBoxContainer/BaseStats/Juice")
 ATKLabel = NodePath("VBoxContainer/BaseStats/ATK")
@@ -36,6 +37,7 @@ DEFLabel = NodePath("VBoxContainer/BaseStats/DEF")
 SPDLabel = NodePath("VBoxContainer/BaseStats/SPD")
 LCKLabel = NodePath("VBoxContainer/BaseStats/LCK")
 HITLabel = NodePath("VBoxContainer/BaseStats/HIT")
+EVALabel = NodePath("VBoxContainer/BaseStats/EVA")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1533613556]
 layout_mode = 2
@@ -96,6 +98,12 @@ layout_mode = 2
 theme_override_fonts/font = ExtResource("1_83ih8")
 theme_override_font_sizes/font_size = 24
 text = "HIT: 0"
+
+[node name="EVA" type="Label" parent="VBoxContainer/BaseStats" unique_id=1770004501]
+layout_mode = 2
+theme_override_fonts/font = ExtResource("1_83ih8")
+theme_override_font_sizes/font_size = 24
+text = "EVA: 0"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer" unique_id=68896515]
 layout_mode = 2
@@ -165,7 +173,7 @@ text = "Heart:"
 [node name="Input" type="SpinBox" parent="VBoxContainer/StatAdjuster/Heart" unique_id=1151563704]
 layout_mode = 2
 min_value = -999.0
-max_value = 9999.0
+max_value = 999999.0
 rounded = true
 
 [node name="Juice" type="HBoxContainer" parent="VBoxContainer/StatAdjuster" unique_id=82060597]
@@ -181,7 +189,7 @@ text = "Juice:"
 [node name="Input" type="SpinBox" parent="VBoxContainer/StatAdjuster/Juice" unique_id=1649137607]
 layout_mode = 2
 min_value = -999.0
-max_value = 9999.0
+max_value = 999999.0
 rounded = true
 
 [node name="ATK" type="HBoxContainer" parent="VBoxContainer/StatAdjuster" unique_id=730813296]
@@ -259,6 +267,22 @@ theme_override_font_sizes/font_size = 24
 text = "HIT:"
 
 [node name="Input" type="SpinBox" parent="VBoxContainer/StatAdjuster/HIT" unique_id=1664237593]
+layout_mode = 2
+min_value = -999.0
+max_value = 9999.0
+rounded = true
+
+[node name="EVA" type="HBoxContainer" parent="VBoxContainer/StatAdjuster" unique_id=1770004502]
+layout_mode = 2
+alignment = 1
+
+[node name="Label" type="Label" parent="VBoxContainer/StatAdjuster/EVA" unique_id=1770004503]
+layout_mode = 2
+theme_override_fonts/font = ExtResource("1_83ih8")
+theme_override_font_sizes/font_size = 24
+text = "EVA:"
+
+[node name="Input" type="SpinBox" parent="VBoxContainer/StatAdjuster/EVA" unique_id=1770004504]
 layout_mode = 2
 min_value = -999.0
 max_value = 9999.0

--- a/scripts/Actor.cs
+++ b/scripts/Actor.cs
@@ -4,6 +4,7 @@ using OmoriSandbox.Battle.Emotions;
 using OmoriSandbox.Battle.Modifier;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace OmoriSandbox.Actors;
@@ -33,6 +34,15 @@ public abstract class Actor
 	/// Fired whenever the actor's animation override changes. See <see cref="PlayAnimation"/> and <see cref="ClearAnimation"/>.
 	/// </summary>
 	public event EventHandler OnAnimationChanged;
+	/// <summary>
+	/// Fired after a <see cref="StatModifier"/> is added to this actor.<br/>
+	/// Not fired for tier or duration changes to a modifier the actor already has.
+	/// </summary>
+	public event EventHandler<StatModifierEventArgs> OnStatModifierAdded;
+	/// <summary>
+	/// Fired after a <see cref="StatModifier"/> is removed from this actor for any reason.
+	/// </summary>
+	public event EventHandler<StatModifierRemovedEventArgs> OnStatModifierRemoved;
 	
 	/// <summary>
 	/// The name of the actor.
@@ -126,7 +136,7 @@ public abstract class Actor
 	/// The actor's base stats without any modifiers.
 	/// </summary>
 	/// <returns></returns>
-	protected virtual Stats GetBaseStats() { return BaseStats; }
+	public virtual Stats GetBaseStats() { return BaseStats; }
 
 	/// <summary>
 	/// Sets the base stats for this actor.
@@ -166,42 +176,36 @@ public abstract class Actor
 	/// <param name="silent">If true, success/failure messages will not be logged.</param>
 	public void AddStatModifier(string modifier, int turns = -1, bool silent = false)
 	{
-		if (StatModifiers.TryGetValue(modifier, out StatModifier m))
+		if (StatModifiers.TryGetValue(modifier, out StatModifier m) && m is not TierStatModifier)
 		{
-			if (m is TierStatModifier tier)
-			{
-				bool success = tier.ApplyTier(1);
-				if (success)
-				{
-                    GD.Print("Increased tier of " + modifier + " on " + Name + " to " + tier.CurrentTier);
-                }
-				if (!silent && tier.SuccessMessage != null)
-					ShowStatMessage(success ? tier.SuccessMessage : tier.FailureMessage);
-				return;
-			}
 			m.RefreshTurns();
 			GD.Print("Refreshed modifier " + modifier + " on " + Name);
+			return;
 		}
-		else
+
+		StatModifier mod = m ?? Database.CreateModifier(modifier);
+		if (mod == null)
 		{
-			StatModifier mod = Database.CreateModifier(modifier);
-			if (mod == null)
-			{
-				GD.PrintErr("Unknown stat modifier: " + modifier);
-				return;
-			}
-
-			if (turns > -1)
-			{
-				mod.SetTurnsLeft(turns);
-			}
-
-			StatModifiers.Add(modifier, mod);
-			mod.OnAdd(this);
-			GD.Print("Added modifier " + modifier + " to " + Name);
-			if (mod is TierStatModifier t && t.SuccessMessage != null && !silent)
-				ShowStatMessage(t.SuccessMessage);
+			GD.PrintErr("Unknown stat modifier: " + modifier);
+			return;
 		}
+
+		if (mod is TierStatModifier)
+		{
+			// tiered modifiers all use AddTierStatModifier so stacking and combining behave the same everywhere
+			AddTierStatModifier(modifier, 1, turns, silent);
+			return;
+		}
+
+		if (turns > -1)
+		{
+			mod.SetTurnsLeft(turns);
+		}
+
+		StatModifiers.Add(modifier, mod);
+		mod.OnAdd(this);
+		GD.Print("Added modifier " + modifier + " to " + Name);
+		NotifyModifierAdded(modifier, mod);
 	}
 
     /// <summary>
@@ -209,16 +213,59 @@ public abstract class Actor
     /// </summary>
     /// <param name="modifier">The name of the tier modifier to add.</param>
     /// <param name="tier">The tier that this modifier will start at.</param>
-    /// <param name="turns">The number of turns left the modifier will start at.</param>
+    /// <param name="turns">The number of turns left the modifier will start at. If unchanged (-1), the modifier's registered duration is kept.</param>
     /// <param name="silent">If true, success/failure messages will not be logged.</param>
-    public void AddTierStatModifier(string modifier, int tier = 1, int turns = 6, bool silent = false)
+    public void AddTierStatModifier(string modifier, int tier = 1, int turns = -1, bool silent = false)
 	{
 		StatModifier mod = Database.CreateModifier(modifier);
 		if (mod is not TierStatModifier t)
 		{
+			if (mod == null)
+			{
+				GD.PrintErr("Unknown stat modifier: " + modifier);
+				return;
+			}
+
 			GD.PushWarning("Tried to add a non-tiered stat modifier with tier and turns: " + modifier);
-			AddStatModifier(modifier, silent: silent);
+			if (StatModifiers.TryGetValue(modifier, out StatModifier held))
+			{
+				held.RefreshTurns();
+				GD.Print("Refreshed modifier " + modifier + " on " + Name);
+				return;
+			}
+			if (turns > -1)
+				mod.SetTurnsLeft(turns);
+			StatModifiers.Add(modifier, mod);
+			mod.OnAdd(this);
+			GD.Print("Added modifier " + modifier + " to " + Name);
+			NotifyModifierAdded(modifier, mod);
 			return;
+		}
+
+		if (CombineEnabled && t.CounterpartId != null
+			&& StatModifiers.TryGetValue(t.CounterpartId, out StatModifier c)
+			&& c is TierStatModifier counterpart)
+		{
+			int net = counterpart.CurrentTier - Math.Clamp(tier, 1, t.MaxTier);
+			if (net > 0)
+			{
+				counterpart.ReduceTier(net);
+				GD.Print("Reduced tier of " + t.CounterpartId + " on " + Name + " to " + net + " via " + modifier);
+				if (!silent && t.SuccessMessage != null)
+					ShowStatMessage(t.SuccessMessage);
+				ClampHealthJuiceToMax();
+				return;
+			}
+			RemoveStatModifierInternal(t.CounterpartId, StatModifierRemovalReason.Combined);
+			if (net == 0)
+			{
+				GD.Print("Removed " + t.CounterpartId + " on " + Name + " via " + modifier + " (neutralized)");
+				if (!silent && t.SuccessMessage != null)
+					ShowStatMessage(t.SuccessMessage);
+				return;
+			}
+
+			tier = -net;
 		}
 		if (StatModifiers.TryGetValue(modifier, out StatModifier m))
 		{
@@ -232,15 +279,18 @@ public abstract class Actor
 			{
 				ShowStatMessage(success ? existing.SuccessMessage : existing.FailureMessage);
 			}
+			ClampHealthJuiceToMax();
 			return;
 		}
 		t.WithTier(tier);
-		t.SetTurnsLeft(turns);
+		if (turns > -1)
+			t.SetTurnsLeft(turns);
 		StatModifiers.Add(modifier, t);
 		t.OnAdd(this);
 		GD.Print("Added modifier " + modifier + " to " + Name);
 		if (!silent && t.SuccessMessage != null)
 			ShowStatMessage(t.SuccessMessage);
+		NotifyModifierAdded(modifier, t);
 	}
 
 	/// <summary>
@@ -249,7 +299,7 @@ public abstract class Actor
 	/// <param name="modifier">The name of the modifier to remove.</param>
 	public void RemoveStatModifier(string modifier)
 	{
-		StatModifiers.Remove(modifier);
+		RemoveStatModifierInternal(modifier, StatModifierRemovalReason.Manual);
 	}
 
 	/// <summary>
@@ -257,7 +307,38 @@ public abstract class Actor
 	/// </summary>
 	public void RemoveAllStatModifiers()
 	{
-		StatModifiers.Clear();
+		foreach (string modifier in StatModifiers.Keys.ToList())
+			RemoveStatModifierInternal(modifier, StatModifierRemovalReason.Cleared);
+	}
+	
+	private void RemoveStatModifierInternal(string modifier, StatModifierRemovalReason reason)
+	{
+		if (!StatModifiers.Remove(modifier, out StatModifier mod))
+			return;
+		GD.Print("Removed modifier " + modifier + " from " + Name + " (" + reason + ")");
+		ClampHealthJuiceToMax();
+		OnStatModifierRemoved?.Invoke(this, new StatModifierRemovedEventArgs(modifier, mod, reason));
+	}
+
+	private void NotifyModifierAdded(string modifier, StatModifier mod)
+	{
+		ClampHealthJuiceToMax();
+		OnStatModifierAdded?.Invoke(this, new StatModifierEventArgs(modifier, mod));
+	}
+
+	private static bool CombineEnabled => BattleManager.Instance != null && BattleManager.Instance.CombinedBuffsDebuffs;
+
+	// keeps current HP/Juice within the (possibly modified) max stats
+	private void ClampHealthJuiceToMax()
+	{
+		if (IsToast || CurrentHP <= 0)
+			return;
+		Stats current = CurrentStats;
+		// never let a max reduction kill the actor
+		if (CurrentHP > current.MaxHP)
+			CurrentHP = Math.Max(1, current.MaxHP);
+		if (CurrentJuice > current.MaxJuice)
+			CurrentJuice = Math.Max(0, current.MaxJuice);
 	}
 
 	private void ShowStatMessage(string message)
@@ -267,16 +348,13 @@ public abstract class Actor
 
 	internal void DecreaseStatTurnCounter()
 	{
-		foreach (var mod in StatModifiers)
+		foreach (var mod in StatModifiers.ToList())
 		{
 			if (mod.Value.TurnsLeft != -1)
 			{
 				mod.Value.DecreaseTurns();
 				if (mod.Value.TurnsLeft <= 0)
-				{
-					GD.Print("Removed modifier " + mod.Key + " from " + Name);
-					StatModifiers.Remove(mod.Key);
-				}
+					RemoveStatModifierInternal(mod.Key, StatModifierRemovalReason.Expired);
 			}
 		}
 	}

--- a/scripts/BattleLogManager.cs
+++ b/scripts/BattleLogManager.cs
@@ -22,6 +22,7 @@ public partial class BattleLogManager : Control
 	[Export] private RichTextLabel ImmediateLabel;
 	[Export] private Font Font;
 	[Export] private Sprite2D Icon;
+	[Export] private Control LineContainer;
 
 	private readonly Queue<string> MessageQueue = [];
 	private readonly Queue<string> LineQueue = [];
@@ -246,6 +247,9 @@ public partial class BattleLogManager : Control
 	{
 		while (LineQueue.Count > 0)
 		{
+			// when the log is full, the new line spawns one slot beneath the box and
+			// gets revealed by the clip mask as the whole stack shifts up, like vanilla
+			bool scrolling = ActiveLines.Count >= 3;
 			while (ActiveLines.Count >= 3)
 			{
 				MoveOffScreen(ActiveLines[0]);
@@ -254,9 +258,9 @@ public partial class BattleLogManager : Control
 
 			Control newLine = LogLine.Instantiate<Control>();
 			newLine.GetNode<Label>("Label").Text = LineQueue.Dequeue();
-			newLine.Position = new Vector2(11, ActiveLines.Count * HEIGHT);
+			newLine.Position = new Vector2(11, (ActiveLines.Count + (scrolling ? 1 : 0)) * HEIGHT);
 			newLine.Modulate = new Color(1f, 1f, 1f, 0f);
-			AddChild(newLine);
+			LineContainer.AddChild(newLine);
 			ActiveLines.Add(newLine);
 
 			Tween tween = GetTree().CreateTween();
@@ -315,7 +319,7 @@ public partial class BattleLogManager : Control
 			.SetTrans(Tween.TransitionType.Sine);
 		tween.TweenProperty(line, "modulate:a", 0f, 0.15f)
 			.SetTrans(Tween.TransitionType.Sine);
-		tween.TweenCallback(Callable.From(() => line.QueueFree()));
+		tween.Chain().TweenCallback(Callable.From(line.QueueFree));
 	}
 
 	private float MessageDelay => 1f - SettingsMenuManager.Instance.BattlelogSpeed * 0.15f;

--- a/scripts/BattleManager.cs
+++ b/scripts/BattleManager.cs
@@ -1058,7 +1058,7 @@ public partial class BattleManager : Node
 			Equipment charm = CurrentParty[CurrentPartyMember].Actor.Charm;
 			BattleLogManager.Instance.ClearAndShowMessage(
 				$"What will {CurrentParty[CurrentPartyMember].Actor.Name.ToUpper()} do?" +
-				$"[font_size=20]\n[ATK: {stats.ATK}, DEF: {stats.DEF}, SPD: {stats.SPD}, LCK: {stats.LCK}, HIT: {stats.HIT}]" +
+				$"[font_size=18]\n[ATK: {stats.ATK}, DEF: {stats.DEF}, SPD: {stats.SPD}, LCK: {stats.LCK}, HIT: {stats.HIT}, EVA: {stats.EVA}]" +
 				$"\n[Weapon: [color=#c263e1]{CurrentParty[CurrentPartyMember].Actor.Weapon.Name}[/color], Charm: [color=#c263e1]{(charm == null ? "None" : charm.Name)}[/color]]");
 		}
 		else
@@ -1751,18 +1751,8 @@ public partial class BattleManager : Node
 	public int Damage(Actor self, Actor target, Func<float> damageFunc, bool neverMiss = true, float variance = 0.2f,
 		bool guaranteeCrit = false, bool neverCrit = false, bool ignoreEmotion = false, string attackElement = null, bool silent = false)
 	{
-		if (!neverMiss)
-		{
-			bool miss = self.CurrentStats.HIT < GameManager.Instance.Random.RandiRange(0, 100);
-			if (miss)
-			{
-				if (!silent) BattleLogManager.Instance.QueueMessage(self, target, "[actor]'s attack missed...");
-				AudioManager.Instance.PlaySFX("BA_miss");
-				// Miss text spawns a little further down
-				SpawnDamageNumber(-1, target.CenterPoint, DamageType.Miss);
-				return -1;
-			}
-		}
+		if (!neverMiss && RollMissOrEvade(self, target, silent))
+			return -1;
 
 		float damage = Math.Max(0, damageFunc());
 		// locked bosses resolve advantage as their locked emotion
@@ -1883,6 +1873,43 @@ public partial class BattleManager : Node
 
 		return roundedInt;
 	}
+	
+	private bool RollMissOrEvade(Actor self, Actor target, bool silent)
+	{
+		int hitRate = self.CurrentStats.HIT;
+		int evasion = target.CurrentStats.EVA;
+		int roll = GameManager.Instance.Random.RandiRange(0, 100);
+		bool miss, evaded;
+		if (SettingsMenuManager.Instance.CombinedAccuracy)
+		{
+			// most OMORI mods use a combined accuracy roll
+			miss = hitRate - evasion < roll;
+			evaded = miss && roll <= hitRate;
+		}
+		else
+		{
+			//  base RPGMaker uses two separate rolls in this order
+			miss = hitRate < roll;
+			evaded = !miss && GameManager.Instance.Random.RandiRange(0, 100) < evasion;
+		}
+
+		if (!miss && !evaded)
+			return false;
+
+		if (evaded)
+		{
+			if (!silent) BattleLogManager.Instance.QueueMessage(self, target, "[target] evaded the attack!");
+			AudioManager.Instance.PlaySFX("GEN_Swish", volume: 0.9f);
+		}
+		else
+		{
+			if (!silent) BattleLogManager.Instance.QueueMessage(self, target, "[actor]'s attack missed...");
+			AudioManager.Instance.PlaySFX("BA_miss");
+		}
+		// Miss text spawns a little further down
+		SpawnDamageNumber(-1, target.CenterPoint, DamageType.Miss);
+		return true;
+	}
 
 	private void ApplyOverrides(DamagePhase phase, ref float damage, Actor attacker, Actor defender, bool isCritical,
 		bool neverMiss)
@@ -1897,7 +1924,7 @@ public partial class BattleManager : Node
 	/// Calculates juice damage. Misses, critical hits, emotion effectiveness, and stat modifiers are all taken into account. Sadness damage reduction, however, is not.
 	/// </summary>
 	/// /// <remarks>
-	/// Unlike <see cref="Damage(Actor, Actor, Func{float}, bool, float, bool, bool, bool)"/>, this method does not play hit sounds, however it does display damage numbers and queues the battle log.
+	/// Unlike <see cref="Damage(Actor, Actor, Func{float}, bool, float, bool, bool, bool, string, bool)"/>, this method does not play hit sounds, however it does display damage numbers and queues the battle log.
 	/// </remarks>
 	/// <param name="self">The attacker.</param>
 	/// <param name="target">The target/defender.</param>
@@ -1914,18 +1941,8 @@ public partial class BattleManager : Node
 	public int DamageJuice(Actor self, Actor target, Func<float> damageFunc, bool neverMiss = true,
 		float variance = 0.2f, bool guaranteeCrit = false, bool neverCrit = false, bool ignoreEmotion = false, string attackElement = null, bool silent = false)
 	{
-		if (!neverMiss)
-		{
-			bool miss = self.CurrentStats.HIT < GameManager.Instance.Random.RandiRange(0, 100);
-			if (miss)
-			{
-				if (!silent) BattleLogManager.Instance.QueueMessage(self, target, "[actor]'s attack missed...");
-				AudioManager.Instance.PlaySFX("BA_miss");
-				// Miss text spawns a little further down
-				SpawnDamageNumber(-1, target.CenterPoint, DamageType.Miss);
-				return -1;
-			}
-		}
+		if (!neverMiss && RollMissOrEvade(self, target, silent))
+			return -1;
 
 		float damage = damageFunc();
 		// locked bosses resolve advantage as their locked emotion

--- a/scripts/BattleManager.cs
+++ b/scripts/BattleManager.cs
@@ -76,12 +76,21 @@ public partial class BattleManager : Node
 	/// </summary>
 	public event EventHandler EnergyChanged;
 
+	/// <summary>
+	/// Fired once per battle when the battle is exited for any reason
+	/// (restart, running away, or returning to the title screen), after the battle state has been fully reset.
+	/// Not fired when the end-of-battle results screen appears or between Boss Rush stages.
+	/// </summary>
+	public event EventHandler BattleExited;
+
 	private bool FollowupActive = false;
 	private bool FollowupSelected = false;
 	private bool ForceHideFollowup = false;
 	private int FollowupTier = 1;
 	private bool DamageNumbersDisabled = false;
 	private bool DebugDamageHeld = false;
+
+	internal bool CombinedBuffsDebuffs { get; private set; }
 
 	private bool RestartQueued = false;
 	private double RestartTimer;
@@ -165,6 +174,7 @@ public partial class BattleManager : Node
 		Energy = Math.Clamp(preset.StartingEnergy, 0, 10);
 		FollowupTier = preset.FollowupTier;
 		DamageNumbersDisabled = preset.DisableDamageNumbers;
+		CombinedBuffsDebuffs = preset.CombinedBuffsDebuffs;
 		EndOfBattleOptionsContainer.Visible = false;
 		StageSelectorContainer.Visible = false;
 
@@ -522,6 +532,7 @@ public partial class BattleManager : Node
 
 	internal void Reset()
 	{
+		bool wasBattling = IsBattling;
 		GameManager.Instance.DespawnAll();
 		AnimationManager.Instance.DespawnAll();
 		AnimationManager.Instance.StopAllAnimations();
@@ -560,6 +571,8 @@ public partial class BattleManager : Node
 		RestartQueued = false;
 		RestartTimer = 1;
 		IsBattling = false;
+		if (wasBattling)
+			BattleExited?.Invoke(this, EventArgs.Empty);
 	}
 
 	private void ReloadPreset()
@@ -987,6 +1000,12 @@ public partial class BattleManager : Node
 			{
 				if (e.Actor.IsToast)
 					continue;
+				foreach (StatModifier modifier in e.Actor.StatModifiers.Values)
+				{
+					RunGuarded(() => modifier.OnStartOfTurn(e.Actor),
+						$"{modifier.GetType().Name}.OnStartOfTurn ({e.Actor.Name})");
+				}
+				
 				await RunGuarded(() => e.Actor.ProcessStartOfTurn(), $"{e.Actor.Name}.ProcessStartOfTurn");
 			}
 
@@ -1509,6 +1528,13 @@ public partial class BattleManager : Node
 
 			ProcessedEndOfTurn = true;
 		}
+		
+		if (RestartQueued)
+		{
+			Reset();
+			ReloadPreset();
+			return;
+		}
 
 		// if any forced commands or priority actors were added during ProcessEndOfTurn, run those still
 		if (ForcedCommands.Count > 0 || PriorityActors.Any(a => !ActedThisTurn.Contains(a) && !IsInvalidTarget(a)))
@@ -1807,6 +1833,18 @@ public partial class BattleManager : Node
 		ApplyOverrides(DamagePhase.PreApply, ref rounded, self, target, critical, neverMiss);
 
 		int roundedInt = (int)rounded;
+		
+		// if damage ends up being below zero due to a stat modifier, treat it as a pseudo-miss
+		// exactly 0 damage still proceeds through as normal
+		if (roundedInt < 0)
+		{
+			// undo the sad juice bleed, the hit never landed
+			target.CurrentJuice += juiceLost;
+			AudioManager.Instance.PlaySFX("BA_miss");
+			SpawnDamageNumber(-1, target.CenterPoint, DamageType.Miss);
+			BattleLogManager.Instance.QueueMessage(self, "[actor]'s attack did nothing.");
+			return -1;
+		}
 		target.Damage(roundedInt);
 		if (target is PartyMember)
 		{
@@ -1933,6 +1971,13 @@ public partial class BattleManager : Node
 		ApplyOverrides(DamagePhase.PreApply, ref rounded, self, target, critical, neverMiss);
 
 		int roundedInt = (int)rounded;
+		// a stat modifier fully negated the hit and drove the damage negative — treat it like a miss
+		if (roundedInt < 0)
+		{
+			AudioManager.Instance.PlaySFX("BA_miss");
+			SpawnDamageNumber(-1, target.CenterPoint, DamageType.Miss);
+			return -1;
+		}
 		target.DamageJuice(roundedInt);
 		SpawnDamageNumber(roundedInt, target.CenterPoint, DamageType.JuiceLoss);
 		if (!silent) BattleLogManager.Instance.QueueMessage(self, target, "[target] lost " + roundedInt + " JUICE...");
@@ -2027,7 +2072,7 @@ public partial class BattleManager : Node
 		// emotions that are weak to all emotions like afraid check for any emotion
 		if (self != neutral && target.DefensiveRateOverrides.TryGetValue("emotion", out float emotionRate))
 		{
-			effect = 0;
+			effect = emotionRate > 1f ? 1 : emotionRate < 1f ? -1 : 0;
 			return damage * emotionRate;
 		}
 

--- a/scripts/BattlePreset.cs
+++ b/scripts/BattlePreset.cs
@@ -55,6 +55,7 @@ internal class BattlePresetEnemy
     public double Layer { get; set; } = 0;
     public bool FallsOffScreen { get; set; } = true;
     public bool GrayscaleOnDefeat { get; set; } = false;
+    public Stats AdjustedStats { get; set; } = new();
 }
 
 internal class BattlePresetBossRushStage

--- a/scripts/BattlePreset.cs
+++ b/scripts/BattlePreset.cs
@@ -22,6 +22,7 @@ internal class BattlePreset
     public bool ShouldSerializeBasilReleaseEnergy() => false;
     public bool DisableDialogue { get; set; } = false;
     public bool DisableDamageNumbers { get; set; } = false;
+    public bool CombinedBuffsDebuffs { get; set; } = false;
     public Dictionary<string, int> Items { get; set; } = [];
 
     [JsonRequired] public List<BattlePresetActor> Actors { get; set; } = [];

--- a/scripts/BattlebackBGMEditorComponent.cs
+++ b/scripts/BattlebackBGMEditorComponent.cs
@@ -124,13 +124,13 @@ internal partial class BattlebackBGMEditorComponent : Control
     {
 	    if (PreviewingBGM)
 	    {
-		    BGMPlayButton.EmitSignal("pressed");
+		    BGMPlayButton.EmitSignal(BaseButton.SignalName.Pressed);
 	    }
     }
 
     public void Load()
     {
-	    BattlebackDropdown.EmitSignal("item_selected", BattlebackDropdown.Selected);
+	    BattlebackDropdown.EmitSignal(OptionButton.SignalName.ItemSelected, BattlebackDropdown.Selected);
 	    BattlebackPreview.SetBattleback(SelectedBattleback);
 	    string bgm = BGMDropdown.GetItemText(BGMDropdown.Selected);
 	    if (AudioManager.Instance.TryGetBGM(bgm, out AudioStreamOggVorbis s))

--- a/scripts/DialogueManager.cs
+++ b/scripts/DialogueManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using OmoriSandbox.Actors;
+using OmoriSandbox.Menu;
 
 namespace OmoriSandbox;
 
@@ -26,6 +27,10 @@ public partial class DialogueManager : Node2D
 	[Export] private NinePatchRect ChoiceBox;
 	[Export] private VBoxContainer ChoiceTextParent;
 
+	// vanilla tints battlecards, energy bar, and battle log while a dialogue box is on screen
+	[Export] private Color UIDimTint = new(0.5f, 0.5f, 0.5f);
+	[Export] private float UIDimDuration = 0.2f;
+
 	private Queue<MessageBox> MessageQueue = [];
 	private bool HasChoice = false;
 
@@ -41,6 +46,8 @@ public partial class DialogueManager : Node2D
 	private int CharsTillSound = 2;
 	private Dictionary<int, List<PauseType>> PauseIndices = [];
 	private Tween OpenCloseTween;
+	private Tween DimTween;
+	private bool UIDimmed;
 
 	private Vector2I CursorNormalPos = new(145, 35);
 	private string[] CurrentChoices;
@@ -493,6 +500,7 @@ public partial class DialogueManager : Node2D
 
 		Visible = true;
 		WaitingForAnimation = true;
+		SetUIDimmed(true);
 		AnimateOpen();
 	}
 
@@ -567,15 +575,49 @@ public partial class DialogueManager : Node2D
 	{
 		Visible = false;
 		WaitingForAnimation = false;
+		SetUIDimmed(false);
 		EmitSignal(SignalName.FinishedDialogue);
 		if (HasChoice)
 			EmitSignal(SignalName.ChoiceSelected, CurrentChoices[ChoiceIndex]);
+	}
+	
+	private static IEnumerable<CanvasItem> GetDimTargets()
+	{
+		if (BattleManager.Instance != null)
+		{
+			foreach (PartyMemberComponent member in BattleManager.Instance.GetAllPartyMembers())
+			{
+				if (member.Battlecard != null)
+					yield return member.Battlecard;
+			}
+		}
+		if (MenuManager.Instance != null)
+			yield return MenuManager.Instance.EnergyDisplay;
+		if (BattleLogManager.Instance != null)
+			yield return BattleLogManager.Instance;
+	}
+
+	private void SetUIDimmed(bool dimmed)
+	{
+		if (UIDimmed == dimmed)
+			return;
+		UIDimmed = dimmed;
+		Color target = dimmed ? UIDimTint : Colors.White;
+		DimTween?.Kill();
+		DimTween = CreateTween().SetParallel();
+		foreach (CanvasItem item in GetDimTargets())
+			DimTween.TweenProperty(item, "modulate", target, UIDimDuration).SetTrans(Tween.TransitionType.Sine);
 	}
 
 	public void Reset()
 	{
 		MessageQueue.Clear();
 		OpenCloseTween?.Kill();
+		// restore UI tint immediately
+		DimTween?.Kill();
+		UIDimmed = false;
+		foreach (CanvasItem item in GetDimTargets())
+			item.Modulate = Colors.White;
 		PauseGeneration++;
 		HasChoice = false;
 		WaitingForAnimation = false;

--- a/scripts/DialogueManager.cs
+++ b/scripts/DialogueManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using OmoriSandbox.Actors;
+using OmoriSandbox.Editor;
 using OmoriSandbox.Menu;
 
 namespace OmoriSandbox;
@@ -85,11 +86,25 @@ public partial class DialogueManager : Node2D
 				return;
 			}
 
+			if (SettingsMenuManager.Instance.InstantDialogue)
+			{
+				// type the whole message at once, scripted pauses and input waits still apply
+				while (IsTyping)
+					TypeChar();
+				CharTimer = 0;
+				return;
+			}
+
+			double delay = TEXT_SPEED / SettingsMenuManager.Instance.DialogueSpeed;
 			CharTimer += delta;
-			if (CharTimer >= TEXT_SPEED)
+			if (CharTimer >= delay)
 			{
 				CharTimer = 0;
-				TypeChar();
+				// when the delay is shorter than a frame, one char per frame can't keep up
+				// type enough chars this frame to hold the configured rate
+				int chars = Math.Max(1, (int)(delta / delay));
+				for (int i = 0; i < chars && IsTyping; i++)
+					TypeChar();
 			}
 		}
 		else if (WaitingForTimer)
@@ -219,13 +234,20 @@ public partial class DialogueManager : Node2D
 		PlaySound();
 	}
 
+	private ulong LastSoundFrame = ulong.MaxValue;
+
 	private void PlaySound()
 	{
 		CharsTillSound--;
 		if (CharsTillSound == 0)
 		{
-			AudioManager.Instance.PlaySFX("SYS_text", GameManager.Instance.Random.RandfRange(0.9f, 1.1f), 0.5f);
 			CharsTillSound = 2;
+			// at high dialogue speeds multiple chars type in one frame, cap at one blip per frame
+			ulong frame = Engine.GetProcessFrames();
+			if (frame == LastSoundFrame)
+				return;
+			LastSoundFrame = frame;
+			AudioManager.Instance.PlaySFX("SYS_text", GameManager.Instance.Random.RandfRange(0.9f, 1.1f), 0.5f);
 		}
 	}
 

--- a/scripts/EditorManager.cs
+++ b/scripts/EditorManager.cs
@@ -315,7 +315,8 @@ internal partial class EditorManager : Node
 			StartingEnergy = (int)StartingEnergySlider.Value,
 			FollowupTier = (int)FollowupTierSlider.Value,
 			DisableDialogue = DisableDialogue.ButtonPressed,
-			DisableDamageNumbers = DisableDamageNumbers.ButtonPressed
+			DisableDamageNumbers = DisableDamageNumbers.ButtonPressed,
+			CombinedBuffsDebuffs = CombinedBuffsDebuffs.ButtonPressed
 		};
 
 		if (EditorMode is GameModeType.Normal)
@@ -474,7 +475,8 @@ internal partial class EditorManager : Node
 		FollowupTierSlider.Value = Math.Clamp(preset.FollowupTier, 1, 3);
 		DisableDialogue.ButtonPressed = preset.DisableDialogue;
 		DisableDamageNumbers.ButtonPressed = preset.DisableDamageNumbers;
-		
+		CombinedBuffsDebuffs.ButtonPressed = preset.CombinedBuffsDebuffs;
+
 		foreach (KeyValuePair<string, int> entry in preset.Items)
 		{
 			HBoxContainer container = new();
@@ -719,6 +721,7 @@ internal partial class EditorManager : Node
 		FollowupTierSlider.Value = 1;
 		DisableDialogue.ButtonPressed = false;
 		DisableDamageNumbers.ButtonPressed = false;
+		CombinedBuffsDebuffs.ButtonPressed = false;
 
 		BGMPreview.Stop();
 		BattlebackBGMEditor.Reset();
@@ -761,6 +764,7 @@ internal partial class EditorManager : Node
     [Export] private Label FollowupTierValue;
     [Export] private CheckBox DisableDialogue;
     [Export] private CheckBox DisableDamageNumbers;
+    [Export] private CheckBox CombinedBuffsDebuffs;
     [Export] private Button AddItemButton;
     [Export] private GridContainer ItemContainer;
     [Export] private LineEdit SearchInput;

--- a/scripts/EditorManager.cs
+++ b/scripts/EditorManager.cs
@@ -96,10 +96,7 @@ internal partial class EditorManager : Node
 			container.AddChild(quantity);
 			Button remove = new();
 			remove.Text = "X";
-			remove.Pressed += () =>
-			{
-				container.QueueFree();
-			};
+			remove.Pressed += container.QueueFree;
 			container.AddChild(remove);
 			ItemContainer.AddChild(container);
 		};
@@ -379,7 +376,8 @@ internal partial class EditorManager : Node
 						Emotion = editor.EmotionDropdown.GetItemText(editor.EmotionDropdown.Selected),
 						Layer = (int)editor.LayerBox.Value,
 						FallsOffScreen = editor.FallsOffScreenCheckbox.ButtonPressed,
-						GrayscaleOnDefeat = editor.GrayscaleOnDefeatCheckbox.ButtonPressed
+						GrayscaleOnDefeat = editor.GrayscaleOnDefeatCheckbox.ButtonPressed,
+						AdjustedStats = editor.GetAdjustedStats()
 					};
 					if (enemy.Emotion is "hurt" or "toast")
 						enemy.Emotion = "neutral";
@@ -415,7 +413,8 @@ internal partial class EditorManager : Node
 								Emotion = enemyEditor.EmotionDropdown.GetItemText(enemyEditor.EmotionDropdown.Selected),
 								Layer = (int)enemyEditor.LayerBox.Value,
 								FallsOffScreen = enemyEditor.FallsOffScreenCheckbox.ButtonPressed,
-								GrayscaleOnDefeat = enemyEditor.GrayscaleOnDefeatCheckbox.ButtonPressed
+								GrayscaleOnDefeat = enemyEditor.GrayscaleOnDefeatCheckbox.ButtonPressed,
+								AdjustedStats = enemyEditor.GetAdjustedStats()
 							};
 							if (enemy.Emotion is "hurt" or "toast")
 								enemy.Emotion = "neutral";

--- a/scripts/EnemyComponent.cs
+++ b/scripts/EnemyComponent.cs
@@ -1,6 +1,7 @@
 using System;
 using Godot;
 using OmoriSandbox.Actors;
+using OmoriSandbox.Battle;
 using OmoriSandbox.Editor;
 
 namespace OmoriSandbox;
@@ -24,11 +25,11 @@ public partial class EnemyComponent : Node
 	/// </summary>
 	public Enemy Actor => Enemy;
 
-	internal void SetEnemy(Enemy enemy, string initialState, bool fallsOffScreen, bool grayscaleOnDefeat, int layer)
+	internal void SetEnemy(Enemy enemy, string initialState, bool fallsOffScreen, bool grayscaleOnDefeat, int layer, Stats adjustedStats = default)
 	{
 		Enemy = enemy;
 		AnimatedSprite2D sprite = GetNode<AnimatedSprite2D>("../Sprite");
-		Enemy.Init(sprite, initialState, fallsOffScreen, grayscaleOnDefeat, layer);
+		Enemy.Init(sprite, initialState, fallsOffScreen, grayscaleOnDefeat, layer, adjustedStats);
 		if (SettingsMenuManager.Instance.ShowMoreInfo)
 			InfoBox = ResourceLoader.Load<PackedScene>("res://scenes/enemy_infobox_moreinfo.tscn")
 				.Instantiate<EnemyMoreInfoBox>();

--- a/scripts/EnemyEditorComponent.cs
+++ b/scripts/EnemyEditorComponent.cs
@@ -17,8 +17,10 @@ internal partial class EnemyEditorComponent : Control
 	[Export] public CheckBox GrayscaleOnDefeatCheckbox { get; private set; }
 	[Export] private CheckBox VisibleCheckbox;
 	[Export] private Button RemoveButton;
+	[Export] private StatAdjustmentEditor StatAdjustmentEditor;
 
 	private AnimatedSprite2D Animator;
+	private Enemy CurrentEnemy;
 
 	// registered emotions plus the pseudo-states enemies can be spawned in
 	private static string[] States => [.. Database.GetAllEmotionIds(), "hurt", "toast"];
@@ -33,6 +35,7 @@ internal partial class EnemyEditorComponent : Control
 		// scroll the (long) enemy list to the current enemy when the dropdown is opened
 		PopupMenu popup = EnemyDropdown.GetPopup();
 		popup.AboutToPopup += () => popup.SetFocusedItem(EnemyDropdown.Selected);
+		StatAdjustmentEditor.StatsAdjusted += RefreshStatDisplay;
 		EmotionDropdown.ItemSelected += (idx) => UpdateState(EmotionDropdown.GetItemText((int)idx));
 
 		VisibleCheckbox.Toggled += (pressed) => Animator.Visible = pressed;
@@ -63,10 +66,10 @@ internal partial class EnemyEditorComponent : Control
 	{
 		if (!enemy.Position.StartsWith("Vector2"))
 			enemy.Position = "Vector2" + enemy.Position;
-		Init(animator, enemy.Name, GD.StrToVar(enemy.Position).AsVector2(), enemy.Emotion, (int)enemy.Layer, enemy.FallsOffScreen, enemy.GrayscaleOnDefeat);
+		Init(animator, enemy.Name, GD.StrToVar(enemy.Position).AsVector2(), enemy.Emotion, (int)enemy.Layer, enemy.FallsOffScreen, enemy.GrayscaleOnDefeat, enemy.AdjustedStats);
 	}
 
-	public void Init(AnimatedSprite2D animator, string name, Vector2 position, string emotion, int layer, bool fallsOffScreen, bool grayscaleOnDefeat)
+	public void Init(AnimatedSprite2D animator, string name, Vector2 position, string emotion, int layer, bool fallsOffScreen, bool grayscaleOnDefeat, Stats adjustedStats = default)
 	{
 		Animator = animator;
 		Animator.Centered = true;
@@ -77,7 +80,8 @@ internal partial class EnemyEditorComponent : Control
 			Animator.QueueFree();
 			QueueFree();
 		};
-		
+
+		StatAdjustmentEditor.SetStats(adjustedStats);
 		Populate(name);
 		EnemyDropdown.Selected = EnemyDropdown.GetItemIndex(name);
 		int emotionIndex = EmotionDropdown.GetItemIndex(emotion);
@@ -144,6 +148,21 @@ internal partial class EnemyEditorComponent : Control
 		int restored = previousEmotion != null ? EmotionDropdown.GetItemIndex(previousEmotion) : -1;
 		EmotionDropdown.Selected = restored > -1 ? restored : 0;
 		UpdateState(EmotionDropdown.GetItemText(EmotionDropdown.Selected));
+
+		CurrentEnemy = enemy;
+		RefreshStatDisplay();
+	}
+
+	private void RefreshStatDisplay()
+	{
+		if (CurrentEnemy == null)
+			return;
+		StatAdjustmentEditor.UpdateStats(CurrentEnemy.DeclaredStats + StatAdjustmentEditor.GetStats());
+	}
+
+	public Stats GetAdjustedStats()
+	{
+		return StatAdjustmentEditor.GetStats();
 	}
 
 	public void UpdateState(string state)

--- a/scripts/EnemyEditorComponent.cs
+++ b/scripts/EnemyEditorComponent.cs
@@ -23,13 +23,16 @@ internal partial class EnemyEditorComponent : Control
 	// registered emotions plus the pseudo-states enemies can be spawned in
 	private static string[] States => [.. Database.GetAllEmotionIds(), "hurt", "toast"];
 
-	public override void _EnterTree()
+	public override void _Ready()
 	{
 		foreach (string member in Database.GetAllEnemyNames())
 			EnemyDropdown.AddItem(member);
 
 		EnemyDropdown.Selected = EnemyDropdown.GetItemIndex("LostSproutMole");
 		EnemyDropdown.ItemSelected += (idx) => Populate(EnemyDropdown.GetItemText((int)idx));
+		// scroll the (long) enemy list to the current enemy when the dropdown is opened
+		PopupMenu popup = EnemyDropdown.GetPopup();
+		popup.AboutToPopup += () => popup.SetFocusedItem(EnemyDropdown.Selected);
 		EmotionDropdown.ItemSelected += (idx) => UpdateState(EmotionDropdown.GetItemText((int)idx));
 
 		VisibleCheckbox.Toggled += (pressed) => Animator.Visible = pressed;
@@ -77,7 +80,15 @@ internal partial class EnemyEditorComponent : Control
 		
 		Populate(name);
 		EnemyDropdown.Selected = EnemyDropdown.GetItemIndex(name);
-		EmotionDropdown.Selected = EmotionDropdown.GetItemIndex(emotion);
+		int emotionIndex = EmotionDropdown.GetItemIndex(emotion);
+		if (emotionIndex == -1)
+		{
+			// the preset carries an emotion this enemy doesn't support
+			GD.PushWarning($"Enemy {name} cannot be spawned as \"{emotion}\", falling back to neutral.");
+			emotionIndex = 0;
+			emotion = EmotionDropdown.GetItemText(0);
+		}
+		EmotionDropdown.Selected = emotionIndex;
 		LayerBox.Value = layer;
 		XPosBox.SetValueNoSignal(position.X);
 		YPosBox.SetValueNoSignal(position.Y);
@@ -114,6 +125,8 @@ internal partial class EnemyEditorComponent : Control
 		FallsOffScreenCheckbox.ButtonPressed = enemy.FallsOffScreen;
 		GrayscaleOnDefeatCheckbox.ButtonPressed = enemy.GrayscaleOnDefeat;
 
+		// keep the selected emotion across enemy changes when the new enemy supports it
+		string previousEmotion = EmotionDropdown.Selected > -1 ? EmotionDropdown.GetItemText(EmotionDropdown.Selected) : null;
 		EmotionDropdown.Clear();
 		foreach (string state in States)
 		{
@@ -128,7 +141,9 @@ internal partial class EnemyEditorComponent : Control
 				EmotionDropdown.AddItem(state);
 			}
 		}
-		EmotionDropdown.Selected = 0;
+		int restored = previousEmotion != null ? EmotionDropdown.GetItemIndex(previousEmotion) : -1;
+		EmotionDropdown.Selected = restored > -1 ? restored : 0;
+		UpdateState(EmotionDropdown.GetItemText(EmotionDropdown.Selected));
 	}
 
 	public void UpdateState(string state)

--- a/scripts/EnemyInfoBox.cs
+++ b/scripts/EnemyInfoBox.cs
@@ -18,7 +18,7 @@ public partial class EnemyInfoBox : Control
 	internal virtual void SetEnemy(Enemy enemy)
 	{
 		Enemy = enemy;
-		HPBar.MaxValue = Enemy.CurrentStats.HP;
+		HPBar.MaxValue = Enemy.CurrentStats.MaxHP;
 		HPBar.Value = Enemy.CurrentHP;
 		NameLabel.Text = Enemy.Name;
 		float width = Mathf.Max(Infobox.CustomMinimumSize.X, NameLabel.GetMinimumSize().X + 15);
@@ -28,6 +28,7 @@ public partial class EnemyInfoBox : Control
 
 	internal virtual void Show(bool show)
 	{
+		HPBar.MaxValue = Enemy.CurrentStats.MaxHP;
 		HPBar.Value = Enemy.CurrentHP;
 		if (SettingsMenuManager.Instance.ShowStateIcons)
 			UpdateStateIcons();

--- a/scripts/EnemyMoreInfoBox.cs
+++ b/scripts/EnemyMoreInfoBox.cs
@@ -14,6 +14,7 @@ public partial class EnemyMoreInfoBox : EnemyInfoBox
 	[Export] private Label DEFLabel;
 	[Export] private Label LCKLabel;
 	[Export] private Label HITLabel;
+	[Export] private Label EVALabel;
 	[Export] private StateAnimator Animator;
 
 	internal override void SetEnemy(Enemy enemy)
@@ -29,8 +30,9 @@ public partial class EnemyMoreInfoBox : EnemyInfoBox
 		DEFLabel.Text = $"DEF: {stats.DEF}";
 		LCKLabel.Text = $"LCK: {stats.LCK}";
 		HITLabel.Text = $"HIT: {stats.HIT}";
+		EVALabel.Text = $"EVA: {stats.EVA}";
 		Animator.SetStateAtlas(Enemy.CurrentEmotion.Id);
-		
+
 		// shift the emotion sprite relative to the size of the name
 		// keeps the sprite centered on the infobox
 		Sprite2D state = Animator.EmotionSprite;
@@ -51,6 +53,7 @@ public partial class EnemyMoreInfoBox : EnemyInfoBox
 		DEFLabel.Text = $"DEF: {stats.DEF}";
 		LCKLabel.Text = $"LCK: {stats.LCK}";
 		HITLabel.Text = $"HIT: {stats.HIT}";
+		EVALabel.Text = $"EVA: {stats.EVA}";
 		Animator.SetStateAtlas(Enemy.CurrentEmotion.Id);
 	}
 }

--- a/scripts/EnemyMoreInfoBox.cs
+++ b/scripts/EnemyMoreInfoBox.cs
@@ -43,6 +43,7 @@ public partial class EnemyMoreInfoBox : EnemyInfoBox
 		base.Show(show);
 		Stats stats = Enemy.CurrentStats;
 		HPLabel.Text = $"{Enemy.CurrentHP}/{stats.MaxHP}";
+		JuiceBar.MaxValue = stats.MaxJuice;
 		JuiceBar.Value = Enemy.CurrentJuice;
 		JuiceLabel.Text = $"{Enemy.CurrentJuice}/{stats.MaxJuice}";
 		ATKLabel.Text = $"ATK: {stats.ATK}";

--- a/scripts/GameManager.cs
+++ b/scripts/GameManager.cs
@@ -19,7 +19,7 @@ public partial class GameManager : Node
 	/// <summary>
 	/// The current version of OmoriSandbox.
 	/// </summary>
-	public const string Version = "OmoriSandbox v1.1.0";
+	public const string Version = "OmoriSandbox v1.1.1";
 	
 	[Export] private PackedScene BattlecardUI;
 	[Export] private PackedScene EnemyNode;
@@ -37,8 +37,8 @@ public partial class GameManager : Node
 	public RandomNumberGenerator Random { get; private set; } = new();
 	internal DiscordManager DiscordManager { get; private set; }
 	public static GameManager Instance { get; private set; }
-
-	private double DisplayedFPS = -1;
+	
+	private double DisplayedFPS = double.MinValue;
 
 	public override void _PhysicsProcess(double delta)
 	{
@@ -49,7 +49,7 @@ public partial class GameManager : Node
 		if (fps != DisplayedFPS)
 		{
 			DisplayedFPS = fps;
-			FPSLabel.Text = $"{(fps >= 0 ? fps : "")} {Version}";
+			FPSLabel.Text = fps >= 0 ? $"{fps} {Version}" : Version;
 		}
 
 		DiscordManager.Tick();

--- a/scripts/GameManager.cs
+++ b/scripts/GameManager.cs
@@ -212,7 +212,7 @@ public partial class GameManager : Node
 		EnemyComponent component = new();
 		node.AddChild(component);
 		node.ZIndex -= (int)enemy.Layer;
-		component.SetEnemy(instance, enemy.Emotion, enemy.FallsOffScreen, enemy.GrayscaleOnDefeat, (int)enemy.Layer);
+		component.SetEnemy(instance, enemy.Emotion, enemy.FallsOffScreen, enemy.GrayscaleOnDefeat, (int)enemy.Layer, enemy.AdjustedStats);
 		return component;
 	}
 

--- a/scripts/MenuManager.cs
+++ b/scripts/MenuManager.cs
@@ -18,6 +18,9 @@ internal partial class MenuManager : Node
 	[Export] private Label EnergyText;
 	private Tween EnergyBarTween;
 
+	// the energy bar node, tinted by the DialogueManager while dialogue is on screen
+	internal Sprite2D EnergyDisplay => EnergyBar;
+
 	public static MenuManager Instance { get; private set; }
 
 	private const float FightRunOffsetRW = 457f;
@@ -94,8 +97,7 @@ internal partial class MenuManager : Node
 		}
 
 		if (ignoreMemory)
-			// this technically ignores the page number, but is only really ever used with the BattleMenu anyway
-			CurrentMenu.OnOpen(new(CurrentState, CurrentMenu.CursorIndex));
+			CurrentMenu.OnOpen(new(CurrentState, CurrentMenu.CursorIndex, (CurrentMenu as PagedMenu)?.Page ?? 0));
 		else if (currentPartyMember != null && LastSelected.TryGetValue(currentPartyMember, out var result))
 			CurrentMenu.OnOpen(result);
 		else
@@ -153,21 +155,15 @@ internal partial class MenuManager : Node
 	{
 		if (LastSelected.ContainsKey(member))
 		{
-			// if we have a saved state for this actor, we don't want to overwrite the value when we select the button again
+			// if the actor selected ATTACK last turn, wipe the memory
 			if (CurrentState == MenuState.Battle && CurrentMenu.CursorIndex > 0)
 				return;
 		}
-		if (CurrentMenu is ItemMenu itemMenu)
+		if (CurrentMenu is PagedMenu pagedMenu)
 		{
-			LastSelected[member] = new(CurrentState, itemMenu.CursorIndex, itemMenu.Page);
+			LastSelected[member] = new(CurrentState, pagedMenu.CursorIndex, pagedMenu.Page);
 			if (SettingsMenuManager.Instance.LogDebug)
-				GD.Print($"Saved {member.Name} selection as {CurrentState} at index {CurrentMenu.CursorIndex}, page {itemMenu.Page}");
-		}
-		else if (CurrentMenu is SkillMenu skillMenu)
-		{
-			LastSelected[member] = new(CurrentState, skillMenu.CursorIndex, skillMenu.Page);
-			if (SettingsMenuManager.Instance.LogDebug)
-				GD.Print($"Saved {member.Name} selection as {CurrentState} at index {CurrentMenu.CursorIndex}, page {skillMenu.Page}");
+				GD.Print($"Saved {member.Name} selection as {CurrentState} at index {CurrentMenu.CursorIndex}, page {pagedMenu.Page}");
 		}
 		else
 		{

--- a/scripts/PartyMemberComponent.cs
+++ b/scripts/PartyMemberComponent.cs
@@ -43,6 +43,10 @@ public partial class PartyMemberComponent : Node
     /// The followup set assigned to the <see cref="Actors.PartyMember"/>, or null when followups are disabled.
     /// </summary>
     internal FollowupSet FollowupSet { get; private set; }
+    /// <summary>
+    /// The battlecard portrait node, tinted by the <see cref="DialogueManager"/> while dialogue is on screen.
+    /// </summary>
+    internal TextureRect Battlecard { get; private set; }
 
     private Timer HurtTimer = new()
     {
@@ -59,6 +63,7 @@ public partial class PartyMemberComponent : Node
 			actor.Emotion = "neutral";
 		if (!PartyMember.Init(face, actor))
 			return false;
+		Battlecard = GetNode<TextureRect>("../Battlecard");
 		HPLabel = GetNode<Label>("../Battlecard/HealthLabel/");
 		HPBar = GetNode<TextureProgressBar>("../Battlecard/Health");
 		JuiceLabel = GetNode<Label>("../Battlecard/JuiceLabel");
@@ -140,6 +145,16 @@ public partial class PartyMemberComponent : Node
 
 	public override void _Process(double delta)
 	{
+		// keep the cached maxes in sync with stat modifiers that change MaxHP/MaxJuice
+		Stats stats = PartyMember.CurrentStats;
+		if (HPBar.MaxValue != stats.MaxHP || JuiceBar.MaxValue != stats.MaxJuice)
+		{
+			HPBar.MaxValue = stats.MaxHP;
+			JuiceBar.MaxValue = stats.MaxJuice;
+			HPLabel.Text = $"{Mathf.RoundToInt(DisplayedHP)}/{HPBar.MaxValue}";
+			JuiceLabel.Text = $"{Mathf.RoundToInt(DisplayedJuice)}/{JuiceBar.MaxValue}";
+		}
+
 		// nothing to animate once the displayed values have settled
 		// ReSharper disable twice CompareOfFloatsByEqualityOperator
 		if (DisplayedHP == PartyMember.CurrentHP && DisplayedJuice == PartyMember.CurrentJuice)

--- a/scripts/SettingsMenuManager.cs
+++ b/scripts/SettingsMenuManager.cs
@@ -102,6 +102,7 @@ public partial class SettingsMenuManager : Control
 		ToysUseEmotionDamageCheckbox.ButtonPressed = (bool)config.GetValue("Settings", "ToysUseEmotionDamage", false);
 		SpaceExHusbandReleaseEnergyCheckbox.ButtonPressed = (bool)config.GetValue("Settings", "SpaceExHusbandReleaseEnergy", false);
 		EnableDebugDamageCheckbox.ButtonPressed = (bool)config.GetValue("Settings", "EnableDebugDamage", false);
+		CombinedAccuracyCheckbox.ButtonPressed = (bool)config.GetValue("Settings", "CombinedAccuracy", false);
 		BattlelogSpeedSlider.Value = (int)config.GetValue("Settings", "BattlelogSpeed", 3);
 		ActionDelaySlider.Value = (int)config.GetValue("Settings", "ActionDelay", 3);
 
@@ -173,7 +174,8 @@ public partial class SettingsMenuManager : Control
 		config.SetValue("Settings", "ToysUseEmotionDamage", ToysUseEmotionDamageCheckbox.ButtonPressed);
 		config.SetValue("Settings", "SpaceExHusbandReleaseEnergy", SpaceExHusbandReleaseEnergyCheckbox.ButtonPressed);
 		config.SetValue("Settings", "EnableDebugDamage", EnableDebugDamageCheckbox.ButtonPressed);
-		
+		config.SetValue("Settings", "CombinedAccuracy", CombinedAccuracyCheckbox.ButtonPressed);
+
 		config.SetValue("Keybinds", "RestartHoldTime", RestartHoldTimeSlider.Value);
 		config.SetValue("Keybinds", "SpeedUpMultiplier", SpeedUpSlider.Value);
 		foreach (Node node in KeybindGrid.GetChildren())
@@ -225,6 +227,7 @@ public partial class SettingsMenuManager : Control
 		config.SetValue("Settings", "ToysUseEmotionDamage", false);
 		config.SetValue("Settings", "SpaceExHusbandReleaseEnergy", false);
 		config.SetValue("Settings", "EnableDebugDamage", false);
+		config.SetValue("Settings", "CombinedAccuracy", false);
 		config.SetValue("Keybinds", "RestartHoldTime", 1d);
 		config.SetValue("Keybinds", "SpeedUpMultiplier", 1.5d);
 		foreach (Node node in KeybindGrid.GetChildren())
@@ -261,6 +264,7 @@ public partial class SettingsMenuManager : Control
 	public bool ToysUseEmotionDamage => ToysUseEmotionDamageCheckbox.ButtonPressed;
 	public bool SpaceExHusbandReleaseEnergy => SpaceExHusbandReleaseEnergyCheckbox.ButtonPressed;
 	public bool EnableDebugDamage => EnableDebugDamageCheckbox.ButtonPressed;
+	public bool CombinedAccuracy => CombinedAccuracyCheckbox.ButtonPressed;
 	public int BattlelogSpeed => (int)BattlelogSpeedSlider.Value;
 	public int ActionDelay => (int)ActionDelaySlider.Value;
 	public bool EnemySelectionWrapping => EnemySelectionWrappingCheckbox.ButtonPressed;
@@ -297,6 +301,7 @@ public partial class SettingsMenuManager : Control
 	[Export] private CheckBox ToysUseEmotionDamageCheckbox;
 	[Export] private CheckBox SpaceExHusbandReleaseEnergyCheckbox;
 	[Export] private CheckBox EnableDebugDamageCheckbox;
+	[Export] private CheckBox CombinedAccuracyCheckbox;
 	[Export] private HSlider RestartHoldTimeSlider;
 	[Export] private Label RestartHoldTimeLabel;
 	[Export] private HSlider SpeedUpSlider;

--- a/scripts/SettingsMenuManager.cs
+++ b/scripts/SettingsMenuManager.cs
@@ -51,6 +51,11 @@ public partial class SettingsMenuManager : Control
 			SpeedUpLabel.Text = $"{value:0.00}x";
 		};
 
+		DialogueSpeedSlider.ValueChanged += value =>
+		{
+			DialogueSpeedLabel.Text = value >= DialogueSpeedSlider.MaxValue ? "Instant" : $"{value:0.00}x";
+		};
+
 		SelectionChangeSpeedSlider.ValueChanged += value =>
 		{
 			SelectionChangeSpeedLabel.Text = $"{value:0.00}";
@@ -105,6 +110,7 @@ public partial class SettingsMenuManager : Control
 		CombinedAccuracyCheckbox.ButtonPressed = (bool)config.GetValue("Settings", "CombinedAccuracy", false);
 		BattlelogSpeedSlider.Value = (int)config.GetValue("Settings", "BattlelogSpeed", 3);
 		ActionDelaySlider.Value = (int)config.GetValue("Settings", "ActionDelay", 3);
+		DialogueSpeedSlider.Value = (double)config.GetValue("Settings", "DialogueSpeed", 1d);
 
 		RestartHoldTimeSlider.Value = (double)config.GetValue("Keybinds", "RestartHoldTime", 1d);
 		SpeedUpSlider.Value = (double)config.GetValue("Keybinds", "SpeedUpMultiplier", 1.5d);
@@ -157,6 +163,7 @@ public partial class SettingsMenuManager : Control
 		config.SetValue("Settings", "SFXVolume", AudioServer.GetBusVolumeLinear(AudioServer.GetBusIndex("SFX")));
 		config.SetValue("Settings", "BattlelogSpeed", (int)BattlelogSpeedSlider.Value);
 		config.SetValue("Settings", "ActionDelay", (int)ActionDelaySlider.Value);
+		config.SetValue("Settings", "DialogueSpeed", DialogueSpeedSlider.Value);
 		config.SetValue("Settings", "ShowFPS", ShowFPSCheckbox.ButtonPressed);
 		config.SetValue("Settings", "LogDebugMessages", LogDebugCheckbox.ButtonPressed);
 		config.SetValue("Settings", "PreventAccidentalRun", PreventRunCheckbox.ButtonPressed);
@@ -210,6 +217,7 @@ public partial class SettingsMenuManager : Control
 		config.SetValue("Settings", "SFXVolume", 1f);
 		config.SetValue("Settings", "BattlelogSpeed", 3);
 		config.SetValue("Settings", "ActionDelay", 3);
+		config.SetValue("Settings", "DialogueSpeed", 1d);
 		config.SetValue("Settings", "ShowFPS", true);
 		config.SetValue("Settings", "LogDebugMessages", false);
 		config.SetValue("Settings", "PreventAccidentalRun", false);
@@ -267,6 +275,8 @@ public partial class SettingsMenuManager : Control
 	public bool CombinedAccuracy => CombinedAccuracyCheckbox.ButtonPressed;
 	public int BattlelogSpeed => (int)BattlelogSpeedSlider.Value;
 	public int ActionDelay => (int)ActionDelaySlider.Value;
+	public double DialogueSpeed => DialogueSpeedSlider.Value;
+	public bool InstantDialogue => DialogueSpeedSlider.Value >= DialogueSpeedSlider.MaxValue;
 	public bool EnemySelectionWrapping => EnemySelectionWrappingCheckbox.ButtonPressed;
 	public double SelectionHoldTime => SelectionHoldTimeSlider.Value;
 	public double SelectionChangeSpeed => SelectionChangeSpeedSlider.Value;
@@ -282,6 +292,8 @@ public partial class SettingsMenuManager : Control
 	[Export] private CheckBox FullscreenCheckbox;
 	[Export] private HSlider BattlelogSpeedSlider;
 	[Export] private HSlider ActionDelaySlider;
+	[Export] private HSlider DialogueSpeedSlider;
+	[Export] private Label DialogueSpeedLabel;
 	[Export] private CheckBox ShowFPSCheckbox;
 	[Export] private CheckBox LogDebugCheckbox;
 	[Export] private CheckBox PreventRunCheckbox;

--- a/scripts/StatAdjustmentEditor.cs
+++ b/scripts/StatAdjustmentEditor.cs
@@ -15,6 +15,7 @@ internal partial class StatAdjustmentEditor : Control
     [Export] private SpinBox SPDBox;
     [Export] private SpinBox LCKBox;
     [Export] private SpinBox HITBox;
+    [Export] private SpinBox EVABox;
     [Export] private Label HeartLabel;
     [Export] private Label JuiceLabel;
     [Export] private Label ATKLabel;
@@ -22,7 +23,8 @@ internal partial class StatAdjustmentEditor : Control
     [Export] private Label SPDLabel;
     [Export] private Label LCKLabel;
     [Export] private Label HITLabel;
-    
+    [Export] private Label EVALabel;
+
     [Signal]
     public delegate void StatsAdjustedEventHandler();
     
@@ -37,6 +39,7 @@ internal partial class StatAdjustmentEditor : Control
         SPDBox.ValueChanged += _ => EmitSignal(SignalName.StatsAdjusted);
         LCKBox.ValueChanged += _ => EmitSignal(SignalName.StatsAdjusted);
         HITBox.ValueChanged += _ => EmitSignal(SignalName.StatsAdjusted);
+        EVABox.ValueChanged += _ => EmitSignal(SignalName.StatsAdjusted);
     }
 
     public Stats GetStats()
@@ -49,7 +52,8 @@ internal partial class StatAdjustmentEditor : Control
             DEF = (int)DEFBox.Value,
             SPD = (int)SPDBox.Value,
             LCK = (int)LCKBox.Value,
-            HIT = (int)HITBox.Value
+            HIT = (int)HITBox.Value,
+            EVA = (int)EVABox.Value
         };
     }
 
@@ -62,6 +66,7 @@ internal partial class StatAdjustmentEditor : Control
         SPDBox.SetValueNoSignal(stats.SPD);
         LCKBox.SetValueNoSignal(stats.LCK);
         HITBox.SetValueNoSignal(stats.HIT);
+        EVABox.SetValueNoSignal(stats.EVA);
     }
 
     public void UpdateStats(Stats stats)
@@ -73,6 +78,7 @@ internal partial class StatAdjustmentEditor : Control
         SPDLabel.Text = "SPD: " + stats.SPD;
         LCKLabel.Text = "LCK: " + stats.LCK;
         HITLabel.Text = "HIT: " + stats.HIT;
+        EVALabel.Text = "EVA: " + stats.EVA;
     }
 
     private void Reset()
@@ -84,6 +90,7 @@ internal partial class StatAdjustmentEditor : Control
         SPDBox.SetValueNoSignal(0);
         LCKBox.SetValueNoSignal(0);
         HITBox.SetValueNoSignal(0);
+        EVABox.SetValueNoSignal(0);
         EmitSignal(SignalName.StatsAdjusted);
     }
     

--- a/scripts/Stats.cs
+++ b/scripts/Stats.cs
@@ -18,8 +18,9 @@ public struct Stats
     public int SPD;
     public int LCK;
     public int HIT;
+    public int EVA;
 
-    public Stats(int hp = 0, int juice = 0, int atk = 0, int def = 0, int spd = 0, int lck = 0, int hit = 0)
+    public Stats(int hp = 0, int juice = 0, int atk = 0, int def = 0, int spd = 0, int lck = 0, int hit = 0, int eva = 0)
     {
         HP = hp;
         MaxHP = hp;
@@ -30,17 +31,19 @@ public struct Stats
         SPD = spd;
         LCK = lck;
         HIT = hit;
+        EVA = eva;
     }
 
     public static Stats operator +(Stats a, Stats b) {
         Stats result = new(
-            Math.Max(1, a.HP + b.HP), 
-            Math.Max(0, a.Juice + b.Juice), 
-            Math.Max(0, a.ATK + b.ATK), 
-            Math.Max(0, a.DEF + b.DEF), 
-            Math.Max(0, a.SPD + b.SPD), 
-            Math.Max(0, a.LCK + b.LCK), 
-            Math.Max(0, a.HIT + b.HIT))
+            Math.Max(1, a.HP + b.HP),
+            Math.Max(0, a.Juice + b.Juice),
+            Math.Max(0, a.ATK + b.ATK),
+            Math.Max(0, a.DEF + b.DEF),
+            Math.Max(0, a.SPD + b.SPD),
+            Math.Max(0, a.LCK + b.LCK),
+            Math.Max(0, a.HIT + b.HIT),
+            Math.Max(0, a.EVA + b.EVA))
             {
                 MaxHP = Math.Max(1, a.HP + b.HP),
                 MaxJuice = Math.Max(0, a.Juice + b.Juice)
@@ -64,6 +67,7 @@ public struct Stats
             StatType.SPD => SPD,
             StatType.LCK => LCK,
             StatType.HIT => HIT,
+            StatType.EVA => EVA,
             _ => throw new ArgumentOutOfRangeException(nameof(stat), stat, null)
         };
     }
@@ -75,7 +79,7 @@ public struct Stats
     /// <param name="value">The value to set the stat to.</param>"
     public void SetStat(StatType stat, int value)
     {
-        if (stat is StatType.MaxJuice or StatType.MaxHP)
+        if (stat is StatType.MaxJuice or StatType.MaxHP or StatType.EVA)
             value = Math.Max(0, value);
         else
             value = SettingsMenuManager.Instance.DisableStatLimit ? Math.Max(1, value) : Math.Clamp(value, 1, 999);
@@ -88,6 +92,7 @@ public struct Stats
             case StatType.SPD: SPD = value; break;
             case StatType.LCK: LCK = value; break;
             case StatType.HIT: HIT = value; break;
+            case StatType.EVA: EVA = value; break;
             default: throw new ArgumentOutOfRangeException(nameof(stat), stat, null);
         }
     }

--- a/scripts/battle/Database.cs
+++ b/scripts/battle/Database.cs
@@ -7303,9 +7303,11 @@ public class Database
 		#region MODIFIERS
 		Modifiers.Add("AttackUp", () => CreateBuffDebuff(new StatBonus(StatType.ATK, 1.1f), new StatBonus(StatType.ATK, 1.25f), new StatBonus(StatType.ATK, 1.5f))
 			.WithMessages("ATTACK rose!", "ATTACK cannot go\nany higher!")
+			.WithCounterpart("AttackDown")
 			.WithStateIcons(new StateIcon("bnw_+1att", "Attack Up 1: x1.1 ATK"), new StateIcon("bnw_+2att", "Attack Up 2: x1.25 ATK"), new StateIcon("bnw_+3att", "Attack Up 3: x1.5 ATK")));
 		Modifiers.Add("AttackDown", () => CreateBuffDebuff(new StatBonus(StatType.ATK, 0.9f), new StatBonus(StatType.ATK, 0.8f), new StatBonus(StatType.ATK, 0.7f))
 			.WithMessages("ATTACK fell.", "ATTACK cannot go\nany lower!")
+			.WithCounterpart("AttackUp")
 			.WithStateIcons(new StateIcon("bnw_-1att", "Attack Down 1: x0.9 ATK"), new StateIcon("bnw_-2att", "Attack Down 2: x0.8 ATK"), new StateIcon("bnw_-3att", "Attack Down 3: x0.7 ATK")));
 		Modifiers.Add("DefenseUp", () =>
 		{
@@ -7313,11 +7315,13 @@ public class Database
 			return CreateBuffDebuff(new StatBonus(StatType.DEF, values[0]), new StatBonus(StatType.DEF, values[1]),
 					new StatBonus(StatType.DEF, values[2]))
 				.WithMessages("DEFENSE rose!", "DEFENSE cannot go\nany higher!")
+				.WithCounterpart("DefenseDown")
 				.WithStateIcons(new StateIcon("bnw_+1def", $"Defense Up 1: x{values[0]} DEF"), new StateIcon("bnw_+2def", $"Defense Up 2: x{values[1]} DEF"), new StateIcon("bnw_+3def", $"Defense Up 3: x{values[2]} DEF"));
 
 		});
 		Modifiers.Add("DefenseDown", () => CreateBuffDebuff(new StatBonus(StatType.DEF, 0.75f), new StatBonus(StatType.DEF, 0.5f), new StatBonus(StatType.DEF, 0.25f))
 			.WithMessages("DEFENSE fell.", "DEFENSE cannot go\nany lower!")
+			.WithCounterpart("DefenseUp")
 			.WithStateIcons(new StateIcon("bnw_-1def", "Defense Down 1: x0.75 DEF"), new StateIcon("bnw_-2def", "Defense Down 2: x0.5 DEF"), new StateIcon("bnw_-3def", "Defense Down 3: x0.25 DEF")));
 		Modifiers.Add("SpeedUp", () =>
 		{
@@ -7325,11 +7329,13 @@ public class Database
 			return CreateBuffDebuff(new StatBonus(StatType.SPD, 1.5f), new StatBonus(StatType.SPD, 2f),
 					new StatBonus(StatType.SPD, speedUp3))
 				.WithMessages("SPEED rose!", "SPEED cannot go\nany higher!")
+				.WithCounterpart("SpeedDown")
 				.WithStateIcons(new StateIcon("bnw_+1spd", "Speed Up 1: x1.5 SPD"), new StateIcon("bnw_+2spd", "Speed Up 2: x2 SPD"), new StateIcon("bnw_+3spd", $"Speed Up 3: x{speedUp3} SPD"));
 
 		});
 		Modifiers.Add("SpeedDown", () => CreateBuffDebuff(new StatBonus(StatType.SPD, 0.8f), new StatBonus(StatType.SPD, 0.5f), new StatBonus(StatType.SPD, 0.25f))
 			.WithMessages("SPEED fell.", "SPEED cannot go\nany lower!")
+			.WithCounterpart("SpeedUp")
 			.WithStateIcons(new StateIcon("bnw_-1spd", "Speed Down 1: x0.8 SPD"), new StateIcon("bnw_-2spd", "Speed Down 2: x0.5 SPD"), new StateIcon("bnw_-3spd", "Speed Down 3: x0.25 SPD")));
 
 		Modifiers.Add("ReleaseEnergy", () => new StatModifier(new StatBonus(StatType.SPD, 1.25f), new StatBonus(StatType.ATK, 1.25f), new StatBonus(StatType.DEF, 1.25f), new StatBonus(StatType.LCK, 1.25f)));

--- a/scripts/battle/StatType.cs
+++ b/scripts/battle/StatType.cs
@@ -12,6 +12,7 @@ public enum StatType
     DEF,
     SPD,
     LCK,
-    HIT
+    HIT,
+    EVA
 #pragma warning restore CS1591
 }

--- a/scripts/battle/modifier/StatModifier.cs
+++ b/scripts/battle/modifier/StatModifier.cs
@@ -110,14 +110,22 @@ public class StatModifier
 
     /// <summary>
     /// Sets the number of turns left on this modifier. If the value exceeds the max turns
-    /// set previously, the max is raised to match (unless the modifier is turnless).
+    /// set previously, the max is raised to match. An explicit duration on a turnless modifier
+    /// converts it into a timed one, so refreshes restore that duration instead of making it infinite.
     /// </summary>
     /// <param name="turnsLeft">The number of turns left to set this modifier to.</param>
     public void SetTurnsLeft(int turnsLeft)
     {
         TurnsLeft = turnsLeft;
-        if (MaxTurns != -1)
+        if (MaxTurns == -1)
+        {
+            if (turnsLeft > -1)
+                MaxTurns = turnsLeft;
+        }
+        else
+        {
             MaxTurns = Math.Max(MaxTurns, turnsLeft);
+        }
     }
 
     /// <summary>

--- a/scripts/battle/modifier/StatModifierEvents.cs
+++ b/scripts/battle/modifier/StatModifierEvents.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace OmoriSandbox.Battle.Modifier;
+
+/// <summary>
+/// The reason a <see cref="StatModifier"/> was removed from an actor.
+/// </summary>
+public enum StatModifierRemovalReason
+{
+    /// <summary>Removed directly, e.g. by a skill or by the modifier itself.</summary>
+    Manual,
+    /// <summary>The modifier's turn counter ran out at the end of a turn.</summary>
+    Expired,
+    /// <summary>Removed as part of clearing all of an actor's modifiers, e.g. when the actor becomes toast.</summary>
+    Cleared,
+    /// <summary>Cancelled out or overpowered by its counterpart under the Combined Buffs/Debuffs setting.</summary>
+    Combined
+}
+
+/// <summary>
+/// Event arguments for <see cref="Actors.Actor.OnStatModifierAdded"/>.
+/// </summary>
+public class StatModifierEventArgs : EventArgs
+{
+    /// <summary>
+    /// The id the modifier is registered under, e.g. "AttackUp".
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// The modifier instance held by the actor.
+    /// </summary>
+    public StatModifier Modifier { get; }
+
+    internal StatModifierEventArgs(string id, StatModifier modifier)
+    {
+        Id = id;
+        Modifier = modifier;
+    }
+}
+
+/// <summary>
+/// Event arguments for <see cref="Actors.Actor.OnStatModifierRemoved"/>.
+/// </summary>
+public sealed class StatModifierRemovedEventArgs : StatModifierEventArgs
+{
+    /// <summary>
+    /// Why the modifier was removed.
+    /// </summary>
+    public StatModifierRemovalReason Reason { get; }
+
+    internal StatModifierRemovedEventArgs(string id, StatModifier modifier, StatModifierRemovalReason reason)
+        : base(id, modifier)
+    {
+        Reason = reason;
+    }
+}

--- a/scripts/battle/modifier/StatModifierEvents.cs
+++ b/scripts/battle/modifier/StatModifierEvents.cs
@@ -13,7 +13,7 @@ public enum StatModifierRemovalReason
     Expired,
     /// <summary>Removed as part of clearing all of an actor's modifiers, e.g. when the actor becomes toast.</summary>
     Cleared,
-    /// <summary>Cancelled out or overpowered by its counterpart under the Combined Buffs/Debuffs setting.</summary>
+    /// <summary>Canceled out or overpowered by its counterpart under the Combined Buffs/Debuffs setting.</summary>
     Combined
 }
 

--- a/scripts/battle/modifier/StatModifierEvents.cs.uid
+++ b/scripts/battle/modifier/StatModifierEvents.cs.uid
@@ -1,0 +1,1 @@
+uid://704hx2t5nkop

--- a/scripts/battle/modifier/TierStatModifier.cs
+++ b/scripts/battle/modifier/TierStatModifier.cs
@@ -111,8 +111,7 @@ public class TierStatModifier : StatModifier
 		return this;
 	}
 
-	// lowers the tier (used when the counterpart partially cancels this modifier);
-	// like ApplyTier, any tier change refreshes the timer — a turnless modifier stays turnless
+	// lowers the tier by one, mainly used by combined buffs/debuffs
 	internal void ReduceTier(int tier)
 	{
 		Tier = Math.Clamp(tier, 1, MaxTier);

--- a/scripts/battle/modifier/TierStatModifier.cs
+++ b/scripts/battle/modifier/TierStatModifier.cs
@@ -8,7 +8,10 @@ namespace OmoriSandbox.Battle.Modifier;
 public class TierStatModifier : StatModifier
 {
 	private int Tier;
-	private int MaxTier;
+	/// <summary>
+	/// The max tier of this modifier. By default, the max tier is the length of the stat bonuses. See <see cref="WithMaxTier"/>.
+	/// </summary>
+	public int MaxTier { get; private set; }
     /// <summary>
     /// The message to display on success.
     /// </summary>
@@ -89,6 +92,31 @@ public class TierStatModifier : StatModifier
 	{
 		MaxTier = tier;
 		return this;
+	}
+
+	/// <summary>
+	/// The id of the opposite-direction modifier declared via <see cref="WithCounterpart"/>, or null.
+	/// </summary>
+	public string CounterpartId { get; private set; }
+
+	/// <summary>
+	/// Declares the opposite-direction modifier of this one (e.g. "AttackDown" for "AttackUp"),
+	/// letting the pair cancel against each other when the Combined Buffs/Debuffs preset setting is enabled.
+	/// Both directions should declare each other.
+	/// </summary>
+	/// <param name="modifierId">The id of the opposite-direction modifier.</param>
+	public TierStatModifier WithCounterpart(string modifierId)
+	{
+		CounterpartId = modifierId;
+		return this;
+	}
+
+	// lowers the tier (used when the counterpart partially cancels this modifier);
+	// like ApplyTier, any tier change refreshes the timer — a turnless modifier stays turnless
+	internal void ReduceTier(int tier)
+	{
+		Tier = Math.Clamp(tier, 1, MaxTier);
+		TurnsLeft = MaxTurns;
 	}
 	
 	/// <summary>

--- a/scripts/enemy/Abbi.cs
+++ b/scripts/enemy/Abbi.cs
@@ -58,7 +58,7 @@ internal sealed class Abbi : Enemy
     {
         if (CurrentHP <= 0) return;
 
-        if (CurrentHP < 4000 && !HasSpoken)
+        if (IsBelowHP(0.5f) && !HasSpoken)
         {
             DialogueManager.Instance.QueueMessage(this, "[shake rate=20]Ngh...", font: DialogueManager.FontType.Jagged);
             await DialogueManager.Instance.WaitForDialogue();

--- a/scripts/enemy/Angel.cs
+++ b/scripts/enemy/Angel.cs
@@ -45,7 +45,7 @@ internal sealed class Angel : Enemy
     {
         if (CurrentHP <= 0) return;
 
-        if (!HasSpoken && CurrentHP < 65)
+        if (!HasSpoken && IsBelowHP(0.5f))
         {
             PartyMember target = BattleManager.Instance.GetPartyMemberAtPosition(2) ?? BattleManager.Instance.GetPartyMember(0);
             DialogueManager.Instance.QueueMessage(this, $"Heh. You surprise me, {target.Name.ToUpper()}!");

--- a/scripts/enemy/AngelAlt.cs
+++ b/scripts/enemy/AngelAlt.cs
@@ -45,7 +45,7 @@ internal sealed class AngelAlt : Enemy
     {
         if (CurrentHP <= 0) return;
 
-        if (!HasSpoken && CurrentHP < 75)
+        if (!HasSpoken && IsBelowHP(0.5f))
         {
             PartyMember target = BattleManager.Instance.GetPartyMemberAtPosition(2) ?? BattleManager.Instance.GetPartyMember(0);
             DialogueManager.Instance.QueueMessage(this, $"Heh. You surprise me, {target.Name.ToUpper()}!");

--- a/scripts/enemy/Boss.cs
+++ b/scripts/enemy/Boss.cs
@@ -23,7 +23,7 @@ internal sealed class Boss : Enemy
 
     public override BattleCommand ProcessAI()
     {
-        if (CurrentHP < 23)
+        if (IsBelowHP(0.153f))
             return new BattleCommand(this, this, Skills["BSSDoNothing"]);
 
         if (HasObserveTarget(out PartyMember observe))
@@ -42,21 +42,21 @@ internal sealed class Boss : Enemy
         if (Stage > 2 || CurrentHP <= 0)
             return;
 
-        if (CurrentHP < 120 && Stage == 0)
+        if (IsBelowHP(0.8f) && Stage == 0)
         {
             DialogueManager.Instance.QueueMessage(this, @"[wave freq=10]Hwehwehwe![/wave][br]\!You weaklings!\! You call that an attack!?");
             await DialogueManager.Instance.WaitForDialogue();
             Stage = 1;
         }
 
-        if (CurrentHP < 60 && Stage <= 1)
+        if (IsBelowHP(0.4f) && Stage <= 1)
         {
             DialogueManager.Instance.QueueMessage(this, @"Hey, that kinda hurt!\! Hmph!\! This isn't fun anymore.");
             await DialogueManager.Instance.WaitForDialogue();
             Stage = 2;
         }
                 
-        if (CurrentHP < 15 && Stage <= 2)
+        if (IsBelowHP(0.1f) && Stage <= 2)
         {
             DialogueManager.Instance.QueueMessage(this, @"Grr...\![br]Now you've made me ANGRY...");
             DialogueManager.Instance.QueueMessage(this, "It's time for my special move!");

--- a/scripts/enemy/Creepypasta.cs
+++ b/scripts/enemy/Creepypasta.cs
@@ -19,7 +19,7 @@ internal sealed class Creepypasta : Enemy
         if (HasObserveTarget(out PartyMember observe))
             return new BattleCommand(this, observe, Skills["CPAttack"]);
         
-        if (CurrentHP < 60)
+        if (IsBelowHP(0.2f))
             goto scare;
 
         switch (CurrentEmotion.Id)

--- a/scripts/enemy/Enemy.cs
+++ b/scripts/enemy/Enemy.cs
@@ -67,7 +67,7 @@ public abstract class Enemy : Actor
 	/// </summary>
 	public Stats AdjustedStats { get; private set; }
 
-	// the enemy's declared stat block, readable before Init for the editor's stat display
+	// the enemy's declared stats, used by the editor stat display
 	internal Stats DeclaredStats => Stats;
 
 	/// <summary>

--- a/scripts/enemy/Enemy.cs
+++ b/scripts/enemy/Enemy.cs
@@ -17,7 +17,7 @@ namespace OmoriSandbox.Actors;
 /// </summary>
 public abstract class Enemy : Actor
 {
-	internal void Init(AnimatedSprite2D sprite, string initialState, bool fallsOffScreen, bool grayscaleOnDefeat, int layer)
+	internal void Init(AnimatedSprite2D sprite, string initialState, bool fallsOffScreen, bool grayscaleOnDefeat, int layer, Stats adjustedStats = default)
 	{
 		SpriteFrames animation = Animation;
 		if (animation == null)
@@ -39,7 +39,8 @@ public abstract class Enemy : Actor
 			SetEmotion("neutral", true);
 		}
 		Sprite.Play();
-		SetBaseStats(Stats);
+		AdjustedStats = adjustedStats;
+		SetBaseStats(Stats + AdjustedStats);
 		CurrentHP = BaseStats.HP;
 		CurrentJuice = BaseStats.Juice;
 		if (startToast)
@@ -59,6 +60,24 @@ public abstract class Enemy : Actor
 			}
 			GD.PrintErr("Unknown skill: " + s);
 		}
+	}
+
+	/// <summary>
+	/// The stat adjustments applied to this enemy by the current preset.
+	/// </summary>
+	public Stats AdjustedStats { get; private set; }
+
+	// the enemy's declared stat block, readable before Init for the editor's stat display
+	internal Stats DeclaredStats => Stats;
+
+	/// <summary>
+	/// Whether this enemy's current HP is strictly below the given fraction of its max HP.<br/>
+	/// Useful for having battle conditions scale when the enemy's stats are adjusted.
+	/// </summary>
+	/// <param name="fraction">The fraction of max HP to compare against.</param>
+	public bool IsBelowHP(float fraction)
+	{
+		return CurrentHP < Mathf.RoundToInt(CurrentStats.MaxHP * fraction);
 	}
 
 	/// <summary>

--- a/scripts/enemy/Enemy.cs
+++ b/scripts/enemy/Enemy.cs
@@ -71,13 +71,13 @@ public abstract class Enemy : Actor
 	internal Stats DeclaredStats => Stats;
 
 	/// <summary>
-	/// Whether this enemy's current HP is strictly below the given fraction of its max HP.<br/>
+	/// Whether this enemy's current HP is equal to or below the given fraction of its max HP.<br/>
 	/// Useful for having battle conditions scale when the enemy's stats are adjusted.
 	/// </summary>
 	/// <param name="fraction">The fraction of max HP to compare against.</param>
 	public bool IsBelowHP(float fraction)
 	{
-		return CurrentHP < Mathf.RoundToInt(CurrentStats.MaxHP * fraction);
+		return CurrentHP <= Mathf.RoundToInt(CurrentStats.MaxHP * fraction);
 	}
 
 	/// <summary>

--- a/scripts/enemy/FearOfDrowning.cs
+++ b/scripts/enemy/FearOfDrowning.cs
@@ -47,7 +47,7 @@ internal sealed class FearOfDrowning : Enemy
 
     public override async Task ProcessBattleConditions()
     {
-        if (CurrentHP < 7210 && Phase == 1)
+        if (IsBelowHP(0.7f) && Phase == 1)
         {
             Phase = 2;
             await AnimationManager.Instance.WaitForTintScreen(Colors.Black, 1f);
@@ -55,7 +55,7 @@ internal sealed class FearOfDrowning : Enemy
             await AnimationManager.Instance.WaitForTintScreen(ColorsExtension.TransparentBlack, 1f);
         }
 
-        if (CurrentHP < 3090 && Phase == 2)
+        if (IsBelowHP(0.3f) && Phase == 2)
         {
             Phase = 3;
             await AnimationManager.Instance.WaitForTintScreen(Colors.Black, 1f);

--- a/scripts/enemy/GatorGuyHero.cs
+++ b/scripts/enemy/GatorGuyHero.cs
@@ -55,7 +55,7 @@ internal sealed class GatorGuyHero : Enemy
     public override Stats GetBaseStats()
     {
         if (CurrentEmotion.Id is "sad" or "angry")
-            return new Stats(6000, 3000, 80, 65, 80, 10, 95);
-        return new Stats(6000, 3000, 80, 65, 70, 10, 95);
+            return new Stats(6000, 3000, 80, 65, 80, 10, 95) + AdjustedStats;
+        return new Stats(6000, 3000, 80, 65, 70, 10, 95) + AdjustedStats;
     }
 }

--- a/scripts/enemy/GatorGuyHero.cs
+++ b/scripts/enemy/GatorGuyHero.cs
@@ -52,7 +52,7 @@ internal sealed class GatorGuyHero : Enemy
         return new BattleCommand(this, SelectTarget(), Skills["GGRoughUp"]);
     }
 
-    protected override Stats GetBaseStats()
+    public override Stats GetBaseStats()
     {
         if (CurrentEmotion.Id is "sad" or "angry")
             return new Stats(6000, 3000, 80, 65, 80, 10, 95);

--- a/scripts/enemy/HumphreyGrande.cs
+++ b/scripts/enemy/HumphreyGrande.cs
@@ -26,7 +26,7 @@ internal sealed class HumphreyGrande : Enemy
 
     public override async Task ProcessBattleConditions()
     {
-        if (CurrentHP < 370)
+        if (IsBelowHP(0.1f))
         {
             DialogueManager.Instance.QueueMessage("HUMPHREY", CenterPoint, @"[wave freq=10.0]Just a warning... it's about to get smelly!\| It's time for you all to get in my belly![/wave]");
             await DialogueManager.Instance.WaitForDialogue();

--- a/scripts/enemy/HumphreyGrandeAlt.cs
+++ b/scripts/enemy/HumphreyGrandeAlt.cs
@@ -26,7 +26,7 @@ internal sealed class HumphreyGrandeAlt : Enemy
 
     public override async Task ProcessBattleConditions()
     {
-        if (CurrentHP < 900)
+        if (IsBelowHP(0.1f))
         {
             DialogueManager.Instance.QueueMessage("HUMPHREY", CenterPoint, @"[wave freq=10.0]Just a warning... it's about to get smelly!\| It's time for you all to get in my belly![/wave]");
             await DialogueManager.Instance.WaitForDialogue();

--- a/scripts/enemy/HumphreySwarm.cs
+++ b/scripts/enemy/HumphreySwarm.cs
@@ -68,7 +68,7 @@ internal sealed class HumphreySwarm : Enemy
 
     public override async Task ProcessBattleConditions()
     {
-        if (CurrentHP < 999 && !HasTransformed)
+        if (IsBelowHP(0.0999f) && !HasTransformed)
         {
             HasTransformed = true;
             await ChangePhase();

--- a/scripts/enemy/HumphreySwarmAlt.cs
+++ b/scripts/enemy/HumphreySwarmAlt.cs
@@ -68,7 +68,7 @@ internal sealed class HumphreySwarmAlt : Enemy
 
     public override async Task ProcessBattleConditions()
     {
-        if (CurrentHP < 999 && !HasTransformed)
+        if (IsBelowHP(0.0999f) && !HasTransformed)
         {
             HasTransformed = true;
             await ChangePhase();

--- a/scripts/enemy/Kim.cs
+++ b/scripts/enemy/Kim.cs
@@ -39,7 +39,7 @@ internal sealed class Kim : Enemy
     {
         if (CurrentHP <= 0) return;
 
-        if (!HasSpoken && CurrentHP < 65)
+        if (!HasSpoken && IsBelowHP(0.5f))
         {
             DialogueManager.Instance.QueueMessage(this, "Your face annoys me!");
             await DialogueManager.Instance.WaitForDialogue();

--- a/scripts/enemy/KingCrawler.cs
+++ b/scripts/enemy/KingCrawler.cs
@@ -49,7 +49,7 @@ internal sealed class KingCrawler : Enemy
     private bool HasSpoken = false;
     public override async Task ProcessBattleConditions()
     {
-        if (CurrentHP < 365 && !HasSpoken)
+        if (IsBelowHP(0.5f) && !HasSpoken)
         {
             DialogueManager.Instance.QueueMessage(this, "[br][shake rate=20][font_size=12]Ssssssssssssssssssss...");
             await DialogueManager.Instance.WaitForDialogue();

--- a/scripts/enemy/KingCrawlerAlt.cs
+++ b/scripts/enemy/KingCrawlerAlt.cs
@@ -49,7 +49,7 @@ internal sealed class KingCrawlerAlt : Enemy
     private bool HasSpoken = false;
     public override async Task ProcessBattleConditions()
     {
-        if (CurrentHP < 3100 && !HasSpoken)
+        if (IsBelowHP(0.5f) && !HasSpoken)
         {
             DialogueManager.Instance.QueueMessage(this, "[br][shake rate=20][font_size=12]Ssssssssssssssssssss...");
             await DialogueManager.Instance.WaitForDialogue();

--- a/scripts/enemy/KiteKid.cs
+++ b/scripts/enemy/KiteKid.cs
@@ -52,7 +52,7 @@ internal sealed class KiteKid : Enemy
         if (CurrentHP <= 0)
             return;
 
-        if (CurrentHP < 188 && !HasSpoken)
+        if (IsBelowHP(0.251f) && !HasSpoken)
         {
             DialogueManager.Instance.QueueMessage(this, "No... This can't be...");
             DialogueManager.Instance.QueueMessage(this, @"The wind...\![br]It's getting weaker!");

--- a/scripts/enemy/KiteKidAlt.cs
+++ b/scripts/enemy/KiteKidAlt.cs
@@ -97,7 +97,7 @@ internal sealed class KiteKidAlt : Enemy
         if (CurrentHP <= 0)
             return;
 
-        if (CurrentHP < 2000 && !HasSpoken)
+        if (IsBelowHP(0.25f) && !HasSpoken)
         {
             DialogueManager.Instance.QueueMessage(this, "No... This can't be...");
             DialogueManager.Instance.QueueMessage(this, @"The wind...\![br]It's getting weaker!");

--- a/scripts/enemy/MrJawsum.cs
+++ b/scripts/enemy/MrJawsum.cs
@@ -57,21 +57,21 @@ internal sealed class MrJawsum : Enemy
         if (Stage > 2) 
             return;
         
-        if (CurrentHP < 495 && Stage == 0)
+        if (IsBelowHP(0.99f) && Stage == 0)
         {
             DialogueManager.Instance.QueueMessage(this, "I WANT THESE KIDS GONE YOU UNDERSTAND!?");
             await DialogueManager.Instance.WaitForDialogue();
             Stage = 1;
         }
         
-        if (CurrentHP < 375 && Stage <= 1)
+        if (IsBelowHP(0.75f) && Stage <= 1)
         {
             DialogueManager.Instance.QueueMessage(this, @"The GATOR GUY who runs them out gets free pizza...\! [shake rate=20]on me!");
             await DialogueManager.Instance.WaitForDialogue();
             Stage = 2;
         }
         
-        if (CurrentHP < 250 && Stage <= 2)
+        if (IsBelowHP(0.5f) && Stage <= 2)
         {
             AudioManager.Instance.PlaySFX("se_thunder_bolt", volume: 0.9f);
             AudioManager.Instance.PlaySFX("se_fire_whoosh", volume: 0.7f);

--- a/scripts/enemy/MrJawsumAlt.cs
+++ b/scripts/enemy/MrJawsumAlt.cs
@@ -57,21 +57,21 @@ internal sealed class MrJawsumAlt : Enemy
         if (Stage > 2) 
             return;
         
-        if (CurrentHP < 2970 && Stage == 0)
+        if (IsBelowHP(0.99f) && Stage == 0)
         {
             DialogueManager.Instance.QueueMessage(this, "I WANT THESE KIDS GONE YOU UNDERSTAND!?");
             await DialogueManager.Instance.WaitForDialogue();
             Stage = 1;
         }
         
-        if (CurrentHP < 2250 && Stage <= 1)
+        if (IsBelowHP(0.75f) && Stage <= 1)
         {
             DialogueManager.Instance.QueueMessage(this, @"The GATOR GUY who runs them out gets free pizza...\! [shake rate=20]on me!");
             await DialogueManager.Instance.WaitForDialogue();
             Stage = 2;
         }
         
-        if (CurrentHP < 1500 && Stage <= 2)
+        if (IsBelowHP(0.5f) && Stage <= 2)
         {
             AudioManager.Instance.PlaySFX("se_thunder_bolt", volume: 0.9f);
             AudioManager.Instance.PlaySFX("se_fire_whoosh", volume: 0.7f);

--- a/scripts/enemy/Mutantheart.cs
+++ b/scripts/enemy/Mutantheart.cs
@@ -57,7 +57,7 @@ internal sealed class Mutantheart : Enemy
     {
         if (CurrentHP <= 0) return;
 
-        if (CurrentHP < 3500 && !HasSpoken)
+        if (IsBelowHP(0.5f) && !HasSpoken)
         {
             DialogueManager.Instance.QueueMessage(this, "[font_size=22][wave freq=10.0]Bluh?");
             await DialogueManager.Instance.WaitForDialogue();

--- a/scripts/enemy/NefariousChip.cs
+++ b/scripts/enemy/NefariousChip.cs
@@ -71,7 +71,7 @@ internal sealed class NefariousChip : Enemy
     {
         if (CurrentHP <= 0) return;
 
-        if (CurrentHP < 1728 && !HasSpoken)
+        if (IsBelowHP(0.5f) && !HasSpoken)
         {
             DialogueManager.Instance.QueueMessage(this, "Mamma-mia...");
             DialogueManager.Instance.QueueMessage(this, @"...\! Is...\![br]Is getting hot in here, no?");

--- a/scripts/enemy/Perfectheart.cs
+++ b/scripts/enemy/Perfectheart.cs
@@ -54,7 +54,7 @@ internal sealed class Perfectheart : Enemy
     public override async Task ProcessBattleConditions()
     {
         // recreate omori bug where phase 2 is skipped if perfectheart is observed
-        if (!HasBeenObserved && CurrentHP < 3500 && !SecondPhase)
+        if (!HasBeenObserved && IsBelowHP(0.35f) && !SecondPhase)
         {
             DialogueManager.Instance.QueueMessage(this, @"Oh...\! You are quite strong.");
             DialogueManager.Instance.QueueMessage(this, "It seems I must try a bit harder.");
@@ -70,7 +70,7 @@ internal sealed class Perfectheart : Enemy
             SecondPhase = true;
         }
 
-        if (CurrentHP < 2500 && !HasSpoken)
+        if (IsBelowHP(0.25f) && !HasSpoken)
         {
             DialogueManager.Instance.QueueMessage(this, @"Hm?\! W-what's this?\! A drop of sweat?");
             DialogueManager.Instance.QueueMessage(this, @"My, my...\! I cannot believe this.");

--- a/scripts/enemy/Pluto.cs
+++ b/scripts/enemy/Pluto.cs
@@ -69,7 +69,7 @@ internal sealed class Pluto : Enemy
     {
         if (CurrentHP <= 0) return;
 
-        if (CurrentHP < 150 && !HasExpanded)
+        if (IsBelowHP(0.5f) && !HasExpanded)
         {
             DialogueManager.Instance.QueueMessage(this, "[br][wave freq=20.0]GWAH[font_size=40]AHAHAH[font_size=52]AHAHA!!!");
             DialogueManager.Instance.QueueMessage(this, "[br]What a splendid show of force!");

--- a/scripts/enemy/PlutoExpanded.cs
+++ b/scripts/enemy/PlutoExpanded.cs
@@ -24,7 +24,7 @@ internal sealed class PlutoExpanded : Enemy
         if (HasObserveTarget(out PartyMember observe))
             return new BattleCommand(this, observe, Skills["PEAttack"]);
         
-        if (CurrentHP < 300)
+        if (IsBelowHP(0.1f))
             return new BattleCommand(this, SelectAllTargets(), Skills["PEEarthsFinale"]);
 
         if (Roll() < 31)
@@ -33,7 +33,7 @@ internal sealed class PlutoExpanded : Enemy
             return new BattleCommand(this, SelectTarget(), Skills["PESubmissionHold"]);
         if (Roll() < 31)
             return new BattleCommand(this, this, Skills["PEDoNothing"]);
-        if (CurrentHP < 1200)
+        if (IsBelowHP(0.4f))
             return new BattleCommand(this, this, Skills["PEExpandFurther"]);
         return new BattleCommand(this, SelectTarget(), Skills["PEHeadbutt"]);
     }
@@ -58,7 +58,7 @@ internal sealed class PlutoExpanded : Enemy
         if (CurrentHP <= 0)
             return;
         
-        if (CurrentHP < 1500 && !HasSpoken)
+        if (IsBelowHP(0.5f) && !HasSpoken)
         {
             DialogueManager.Instance.QueueMessage("PLUTO", CenterPoint, @"...\! Ah.\! I see.");
             DialogueManager.Instance.QueueMessage("PLUTO", CenterPoint, "You have all gotten stronger.");

--- a/scripts/enemy/PlutoExpandedAlt.cs
+++ b/scripts/enemy/PlutoExpandedAlt.cs
@@ -24,7 +24,7 @@ internal sealed class PlutoExpandedAlt : Enemy
         if (HasObserveTarget(out PartyMember observe))
             return new BattleCommand(this, observe, Skills["PEAttack"]);
         
-        if (CurrentHP < 1000)
+        if (IsBelowHP(0.1f))
             return new BattleCommand(this, SelectAllTargets(), Skills["PEEarthsFinale"]);
 
         if (Roll() < 31)
@@ -33,7 +33,7 @@ internal sealed class PlutoExpandedAlt : Enemy
             return new BattleCommand(this, SelectTarget(), Skills["PESubmissionHold"]);
         if (Roll() < 31)
             return new BattleCommand(this, this, Skills["PEDoNothing"]);
-        if (CurrentHP < 4000)
+        if (IsBelowHP(0.4f))
             return new BattleCommand(this, this, Skills["PEExpandFurther"]);
         return new BattleCommand(this, SelectTarget(), Skills["PEHeadbutt"]);
     }
@@ -58,7 +58,7 @@ internal sealed class PlutoExpandedAlt : Enemy
         if (CurrentHP <= 0)
             return;
         
-        if (CurrentHP < 5000 && !HasSpoken)
+        if (IsBelowHP(0.5f) && !HasSpoken)
         {
             DialogueManager.Instance.QueueMessage("PLUTO", CenterPoint, @"...\! Ah.\! I see.");
             DialogueManager.Instance.QueueMessage("PLUTO", CenterPoint, "You have all gotten stronger.");

--- a/scripts/enemy/PlutoExpandedEarth.cs
+++ b/scripts/enemy/PlutoExpandedEarth.cs
@@ -101,7 +101,7 @@ internal sealed class PlutoExpandedEarth : Enemy
         if (CurrentHP <= 0)
             return;
 
-        if (CurrentHP < 5000 && !HasThrownEarth)
+        if (IsBelowHP(0.5f) && !HasThrownEarth)
         {
             DialogueManager.Instance.QueueMessage("PLUTO", CenterPoint, @"Ah...\! It seems that I have underestimated you once again.");
             await DialogueManager.Instance.WaitForDialogue();
@@ -113,7 +113,7 @@ internal sealed class PlutoExpandedEarth : Enemy
             }
         }
         
-        if (CurrentHP < 5000 && !HasSpoken)
+        if (IsBelowHP(0.5f) && !HasSpoken)
         {
             DialogueManager.Instance.QueueMessage("PLUTO", CenterPoint, @"Very few have pushed me this far...\! and none have left the same.");
             DialogueManager.Instance.QueueMessage("PLUTO", CenterPoint, @"I want nothing more than victory!\! Let me show you my resolve!");

--- a/scripts/enemy/Recyclepath.cs
+++ b/scripts/enemy/Recyclepath.cs
@@ -53,7 +53,7 @@ internal sealed class Recyclepath : Enemy
     {
         if (CurrentHP <= 0) return;
         
-        if (CurrentHP < 500 && !HasSpoken)
+        if (IsBelowHP(0.5f) && !HasSpoken)
         {
             DialogueManager.Instance.QueueMessage("THE RECYCLEPATH", CenterPoint, "[br]Oh, HOLY BIN in the sky...");
             DialogueManager.Instance.QueueMessage("THE RECYCLEPATH", CenterPoint, "[br]Please grant me the power to recycle thy enemies!");

--- a/scripts/enemy/Roboheart.cs
+++ b/scripts/enemy/Roboheart.cs
@@ -21,7 +21,7 @@ internal sealed class Roboheart : Enemy
         if (HasObserveTarget(out PartyMember observe))
             return new BattleCommand(this, observe, Skills["RHAttack"]);
         
-        if (CurrentHP < 250)
+        if (IsBelowHP(0.1f))
             return new BattleCommand(this, SelectAllTargets(), Skills["RHExplode"]);
 
         switch (CurrentEmotion.Id)
@@ -77,14 +77,14 @@ internal sealed class Roboheart : Enemy
         if (Stage > 1)
             return;
 
-        if (CurrentHP < 1875 && Stage == 0)
+        if (IsBelowHP(0.75f) && Stage == 0)
         {
             DialogueManager.Instance.QueueMessage(this, "TXkgbGlmZSBpcyBzdW\nZmZXJpbmch");
             await DialogueManager.Instance.WaitForDialogue();
             Stage = 1;
         }
         
-        if (CurrentHP < 625 && Stage <= 1)
+        if (IsBelowHP(0.25f) && Stage <= 1)
         {
             DialogueManager.Instance.QueueMessage(this, "SGVscC4uLiBtZS4uLgo=");
             await DialogueManager.Instance.WaitForDialogue();

--- a/scripts/enemy/SirMaximusI.cs
+++ b/scripts/enemy/SirMaximusI.cs
@@ -67,7 +67,7 @@ internal sealed class SirMaximusI : Enemy
     
     public override async Task ProcessBattleConditions()
     {
-        if (CurrentHP < 120 && !UltimateAttack)
+        if (IsBelowHP(0.2f) && !UltimateAttack)
         {
             DialogueManager.Instance.QueueMessage(this, "Behold! My family has spent generations perfecting this technique...");
             DialogueManager.Instance.QueueMessage(this, "[br]This is my ultimate attack!");
@@ -77,7 +77,7 @@ internal sealed class SirMaximusI : Enemy
             return;
         }
         
-        if (CurrentHP < 300 && !FirstDialogue)
+        if (IsBelowHP(0.5f) && !FirstDialogue)
         {
             DialogueManager.Instance.QueueMessage(this, @"No... \!I...\![br]I cannot fail now.");
             DialogueManager.Instance.QueueMessage(this, "My son needs me!");

--- a/scripts/enemy/SirMaximusII.cs
+++ b/scripts/enemy/SirMaximusII.cs
@@ -81,13 +81,32 @@ internal sealed class SirMaximusII : Enemy
         if (IsBelowHP(0.5f) && !FirstDialogue)
         {
             DialogueManager.Instance.QueueMessage(this, "No... I cannot let my father's death be in vain!");
-            DialogueManager.Instance.QueueMessage(this, "Now for my ultimate attack!");
             await DialogueManager.Instance.WaitForDialogue();
             FirstDialogue = true;
         }
         
         if (IsBelowHP(0.2f) && !UltimateAttack)
         {
+            Sprite2D ghost = new()
+            {
+                Texture = ImageTexture.CreateFromImage(Image.LoadFromFile("res://assets/pictures/Maximus.png")),
+                Scale = new Vector2(0.75f, 0.75f),
+                Modulate = Colors.Transparent,
+                GlobalPosition = new Vector2(190, 198),
+                Centered = true,
+                ZIndex = Layer
+            };
+            BattleManager.Instance.AddChild(ghost);
+            Tween tween = BattleManager.Instance.CreateTween();
+            tween.TweenProperty(ghost, "global_position:y", 188, 1.25f);
+            tween.Parallel().TweenProperty(ghost, "modulate:a", 1, 1.25f);
+            tween.TweenProperty(ghost, "global_position:y", 198, 1.25f);
+            tween.TweenProperty(ghost, "global_position:y", 188, 1.25f);
+            tween.Parallel().TweenProperty(ghost, "modulate:a", 0, 1.25f);
+            tween.TweenInterval(0.25f);
+            await BattleManager.Instance.ToSignal(tween, Tween.SignalName.Finished);
+            ghost.QueueFree();
+            
             BattleManager.Instance.ForceCommand(this, SelectAllTargets(), Skills["SMIIUltimateAttack"]);
             UltimateAttack = true;
         }

--- a/scripts/enemy/SirMaximusII.cs
+++ b/scripts/enemy/SirMaximusII.cs
@@ -78,7 +78,7 @@ internal sealed class SirMaximusII : Enemy
     
     public override async Task ProcessBattleConditions()
     {
-        if (CurrentHP < 375 && !FirstDialogue)
+        if (IsBelowHP(0.5f) && !FirstDialogue)
         {
             DialogueManager.Instance.QueueMessage(this, "No... I cannot let my father's death be in vain!");
             DialogueManager.Instance.QueueMessage(this, "Now for my ultimate attack!");
@@ -86,7 +86,7 @@ internal sealed class SirMaximusII : Enemy
             FirstDialogue = true;
         }
         
-        if (CurrentHP < 150 && !UltimateAttack)
+        if (IsBelowHP(0.2f) && !UltimateAttack)
         {
             BattleManager.Instance.ForceCommand(this, SelectAllTargets(), Skills["SMIIUltimateAttack"]);
             UltimateAttack = true;

--- a/scripts/enemy/SirMaximusIII.cs
+++ b/scripts/enemy/SirMaximusIII.cs
@@ -89,13 +89,52 @@ internal sealed class SirMaximusIII : Enemy
         if (IsBelowHP(0.5f) && !FirstDialogue)
         {
             DialogueManager.Instance.QueueMessage(this, "No... I cannot let my father's and his father's deaths be in vain!");
-            DialogueManager.Instance.QueueMessage(this, "Now for my ultimate attack!");
             await DialogueManager.Instance.WaitForDialogue();
             FirstDialogue = true;
         }
         
         if (IsBelowHP(0.2f) && !UltimateAttack)
         {
+            
+            Sprite2D ghost = new()
+            {
+                Texture = ImageTexture.CreateFromImage(Image.LoadFromFile("res://assets/pictures/Maximus.png")),
+                Scale = new Vector2(0.75f, 0.75f),
+                Modulate = Colors.Transparent,
+                GlobalPosition = new Vector2(190, 198),
+                Centered = true,
+                ZIndex = Layer
+            };
+            
+            Sprite2D ghost2 = new()
+            {
+                Texture = ImageTexture.CreateFromImage(Image.LoadFromFile("res://assets/pictures/Maximus.png")),
+                Scale = new Vector2(0.75f, 0.75f),
+                Modulate = Colors.Transparent,
+                GlobalPosition = new Vector2(415, 198),
+                Centered = true,
+                ZIndex = Layer
+            };
+            BattleManager.Instance.AddChild(ghost);
+            BattleManager.Instance.AddChild(ghost2);
+            Tween tween = BattleManager.Instance.CreateTween();
+            Tween tween2 = BattleManager.Instance.CreateTween();
+            tween.TweenProperty(ghost, "global_position:y", 188, 1.25f);
+            tween.Parallel().TweenProperty(ghost, "modulate:a", 1, 1.25f);
+            tween2.TweenProperty(ghost2, "global_position:y", 188, 1.25f);
+            tween2.Parallel().TweenProperty(ghost2, "modulate:a", 1, 1.25f);
+            tween.TweenProperty(ghost, "global_position:y", 198, 1.25f);
+            tween2.TweenProperty(ghost2, "global_position:y", 198, 1.25f);
+            tween.TweenProperty(ghost, "global_position:y", 188, 1.25f);
+            tween.Parallel().TweenProperty(ghost, "modulate:a", 0, 1.25f);
+            tween2.TweenProperty(ghost2, "global_position:y", 188, 1.25f);
+            tween2.Parallel().TweenProperty(ghost2, "modulate:a", 0, 1.25f);
+            tween.TweenInterval(0.25f);
+            tween2.TweenInterval(0.25f);
+            await BattleManager.Instance.ToSignal(tween, Tween.SignalName.Finished);
+            ghost.QueueFree();
+            ghost2.QueueFree();
+            
             BattleManager.Instance.ForceCommand(this, SelectAllTargets(), Skills["SMIIIUltimateAttack"]);
             UltimateAttack = true;
         }

--- a/scripts/enemy/SirMaximusIII.cs
+++ b/scripts/enemy/SirMaximusIII.cs
@@ -86,7 +86,7 @@ internal sealed class SirMaximusIII : Enemy
     
     public override async Task ProcessBattleConditions()
     {
-        if (CurrentHP < 550 && !FirstDialogue)
+        if (IsBelowHP(0.5f) && !FirstDialogue)
         {
             DialogueManager.Instance.QueueMessage(this, "No... I cannot let my father's and his father's deaths be in vain!");
             DialogueManager.Instance.QueueMessage(this, "Now for my ultimate attack!");
@@ -94,7 +94,7 @@ internal sealed class SirMaximusIII : Enemy
             FirstDialogue = true;
         }
         
-        if (CurrentHP < 220 && !UltimateAttack)
+        if (IsBelowHP(0.2f) && !UltimateAttack)
         {
             BattleManager.Instance.ForceCommand(this, SelectAllTargets(), Skills["SMIIIUltimateAttack"]);
             UltimateAttack = true;

--- a/scripts/enemy/SlimeGirls.cs
+++ b/scripts/enemy/SlimeGirls.cs
@@ -113,13 +113,17 @@ internal sealed class SlimeGirls : Enemy
 			BattleManager.Instance.ForceCommand(this, SelectAllTargets(), Skills["Swap"]);
 			Stage = 2;
 		}
-		
-        if (CurrentHP < 1425 && Stage <= 2)
-        {
-            BattleManager.Instance.ForceCommand(this, SelectAllTargets(), Skills["SlimeUltimateAttack"]);
-            Stage = 3;
-        }
-    }
+	}
+
+	public override Task ProcessEndOfTurn()
+	{
+		if (CurrentHP > 0 && CurrentHP < 1425 && Stage <= 2)
+		{
+			BattleManager.Instance.ForceCommand(this, SelectAllTargets(), Skills["SlimeUltimateAttack"]);
+			Stage = 3;
+		}
+		return Task.CompletedTask;
+	}
 
 	public override async Task OnDefeat()
 	{

--- a/scripts/enemy/SlimeGirls.cs
+++ b/scripts/enemy/SlimeGirls.cs
@@ -94,7 +94,7 @@ internal sealed class SlimeGirls : Enemy
 		if (Stage > 2)
 			return;
 
-		if (CurrentHP < 4275 && Stage == 0)
+		if (IsBelowHP(0.75f) && Stage == 0)
 		{
 			DialogueManager.Instance.QueueMessage("MEDUSA", CenterPoint, @"Hmph...\! You kids are more resilient than expected.");
 			DialogueManager.Instance.QueueMessage("MARINA", CenterPoint, @"You know what that means.\! It's time to get serious!");
@@ -104,7 +104,7 @@ internal sealed class SlimeGirls : Enemy
 			Stage = 1;
 		}
 		
-		if (CurrentHP < 2850 && Stage <= 1)
+		if (IsBelowHP(0.5f) && Stage <= 1)
 		{
 			DialogueManager.Instance.QueueMessage("MARINA", CenterPoint, "Hey, MEDUSA![br]Are you thinkin' what I'm thinkin'?");
 			DialogueManager.Instance.QueueMessage("MEDUSA", CenterPoint, @"Yes, sister...\! I think it's about time we switched things up.");
@@ -117,7 +117,7 @@ internal sealed class SlimeGirls : Enemy
 
 	public override Task ProcessEndOfTurn()
 	{
-		if (CurrentHP > 0 && CurrentHP < 1425 && Stage <= 2)
+		if (CurrentHP > 0 && IsBelowHP(0.25f) && Stage <= 2)
 		{
 			BattleManager.Instance.ForceCommand(this, SelectAllTargets(), Skills["SlimeUltimateAttack"]);
 			Stage = 3;

--- a/scripts/enemy/SlimeGirlsAlt.cs
+++ b/scripts/enemy/SlimeGirlsAlt.cs
@@ -94,7 +94,7 @@ internal sealed class SlimeGirlsAlt : Enemy
 		if (Stage > 2)
 			return;
 
-		if (CurrentHP < 6000 && Stage == 0)
+		if (IsBelowHP(0.75f) && Stage == 0)
 		{
 			DialogueManager.Instance.QueueMessage("MEDUSA", CenterPoint, @"Hmph...\! You kids are more resilient than expected.");
 			DialogueManager.Instance.QueueMessage("MARINA", CenterPoint, @"You know what that means.\! It's time to get serious!");
@@ -104,7 +104,7 @@ internal sealed class SlimeGirlsAlt : Enemy
 			Stage = 1;
 		}
 		
-		if (CurrentHP < 4000 && Stage <= 1)
+		if (IsBelowHP(0.5f) && Stage <= 1)
 		{
 			DialogueManager.Instance.QueueMessage("MARINA", CenterPoint, "Hey, MEDUSA![br]Are you thinkin' what I'm thinkin'?");
 			DialogueManager.Instance.QueueMessage("MEDUSA", CenterPoint, @"Yes, sister...\! I think it's about time we switched things up.");
@@ -117,7 +117,7 @@ internal sealed class SlimeGirlsAlt : Enemy
 
 	public override Task ProcessEndOfTurn()
 	{
-		if (CurrentHP > 0 && CurrentHP < 2000 && Stage <= 2)
+		if (CurrentHP > 0 && IsBelowHP(0.25f) && Stage <= 2)
 		{
 			BattleManager.Instance.ForceCommand(this, SelectAllTargets(), Skills["SlimeUltimateAttack"]);
 			Stage = 3;

--- a/scripts/enemy/SlimeGirlsAlt.cs
+++ b/scripts/enemy/SlimeGirlsAlt.cs
@@ -113,13 +113,17 @@ internal sealed class SlimeGirlsAlt : Enemy
 			BattleManager.Instance.ForceCommand(this, SelectAllTargets(), Skills["Swap"]);
 			Stage = 2;
 		}
-		
-        if (CurrentHP < 2000 && Stage <= 2)
-        {
-            BattleManager.Instance.ForceCommand(this, SelectAllTargets(), Skills["SlimeUltimateAttack"]);
-            Stage = 3;
-        }
-    }
+	}
+
+	public override Task ProcessEndOfTurn()
+	{
+		if (CurrentHP > 0 && CurrentHP < 2000 && Stage <= 2)
+		{
+			BattleManager.Instance.ForceCommand(this, SelectAllTargets(), Skills["SlimeUltimateAttack"]);
+			Stage = 3;
+		}
+		return Task.CompletedTask;
+	}
 
 	public override async Task OnDefeat()
 	{

--- a/scripts/enemy/SnaleyThree.cs
+++ b/scripts/enemy/SnaleyThree.cs
@@ -45,7 +45,7 @@ public class SnaleyThree : Enemy
     private bool ReleasedEnergy = false;
     public override async Task ProcessBattleConditions()
     {
-        if (CurrentHP < 600 && !ReleasedEnergy)
+        if (IsBelowHP(0.3f) && !ReleasedEnergy)
         {
             DialogueManager.Instance.QueueMessage(this, "And now it's time for my [wave freq=10.0][color=#6095ff]ULTIMATE SKILL!");
             await DialogueManager.Instance.WaitForDialogue();

--- a/scripts/enemy/SpaceExBoyfriend.cs
+++ b/scripts/enemy/SpaceExBoyfriend.cs
@@ -118,7 +118,7 @@ internal sealed class SpaceExBoyfriend : Enemy
         if (Stage > 2)
             return;
 
-        if (CurrentHP < 1013 && Stage == 0)
+        if (IsBelowHP(0.7504f) && Stage == 0)
         {
             DialogueManager.Instance.QueueMessage(this, "[br]My rage cannot be contained...[br]You cannot placate me!");
             await DialogueManager.Instance.WaitForDialogue();
@@ -130,7 +130,7 @@ internal sealed class SpaceExBoyfriend : Enemy
             Stage = 1;
         }
         
-        if (CurrentHP < 675 && Stage <= 1)
+        if (IsBelowHP(0.5f) && Stage <= 1)
         {
             UnlockEmotion();
             DialogueManager.Instance.QueueMessage(this, @"[br]Gah!\! How are you still moving!?");
@@ -143,7 +143,7 @@ internal sealed class SpaceExBoyfriend : Enemy
             Stage = 2;
         }
         
-        if (CurrentHP < 338 && Stage <= 2)
+        if (IsBelowHP(0.2504f) && Stage <= 2)
         {
             UnlockEmotion();
             DialogueManager.Instance.QueueMessage(this, "[br]Out of my way, earthly scum!");

--- a/scripts/enemy/SpaceExBoyfriendAlt.cs
+++ b/scripts/enemy/SpaceExBoyfriendAlt.cs
@@ -118,7 +118,7 @@ internal sealed class SpaceExBoyfriendAlt : Enemy
         if (Stage > 2)
             return;
 
-        if (CurrentHP < 5250 && Stage == 0)
+        if (IsBelowHP(0.75f) && Stage == 0)
         {
             DialogueManager.Instance.QueueMessage(this, "[br]My rage cannot be contained...[br]You cannot placate me!");
             await DialogueManager.Instance.WaitForDialogue();
@@ -130,7 +130,7 @@ internal sealed class SpaceExBoyfriendAlt : Enemy
             Stage = 1;
         }
         
-        if (CurrentHP < 3500 && Stage <= 1)
+        if (IsBelowHP(0.5f) && Stage <= 1)
         {
             UnlockEmotion();
             DialogueManager.Instance.QueueMessage(this, @"[br]Gah!\! How are you still moving!?");
@@ -143,7 +143,7 @@ internal sealed class SpaceExBoyfriendAlt : Enemy
             Stage = 2;
         }
         
-        if (CurrentHP < 1750 && Stage <= 2)
+        if (IsBelowHP(0.25f) && Stage <= 2)
         {
             UnlockEmotion();
             DialogueManager.Instance.QueueMessage(this, "[br]Out of my way, earthly scum!");

--- a/scripts/enemy/SpaceExHusband.cs
+++ b/scripts/enemy/SpaceExHusband.cs
@@ -269,7 +269,7 @@ internal sealed class SpaceExHusband : Enemy
         await DialogueManager.Instance.WaitForDialogue();
     }
 
-    protected override Stats GetBaseStats()
+    public override Stats GetBaseStats()
     {
         return GetStatsForEmotion();
     }

--- a/scripts/enemy/SpaceExHusband.cs
+++ b/scripts/enemy/SpaceExHusband.cs
@@ -271,6 +271,6 @@ internal sealed class SpaceExHusband : Enemy
 
     public override Stats GetBaseStats()
     {
-        return GetStatsForEmotion();
+        return GetStatsForEmotion() + AdjustedStats;
     }
 }

--- a/scripts/enemy/Sweetheart.cs
+++ b/scripts/enemy/Sweetheart.cs
@@ -173,7 +173,7 @@ internal sealed class Sweetheart : Enemy
 		UsedDonut = false;
 	}
 
-	protected override Stats GetBaseStats()
+	public override Stats GetBaseStats()
 	{
 		if (CurrentEmotion.Id is "ecstatic" or "manic")
 			return new Stats(3300, 1650, 30, 25, 40, 30, 90);

--- a/scripts/enemy/Sweetheart.cs
+++ b/scripts/enemy/Sweetheart.cs
@@ -107,7 +107,7 @@ internal sealed class Sweetheart : Enemy
 		if (Stage > 3)
 			return;
 		
-		if (CurrentHP < 2640 && Stage == 0)
+		if (IsBelowHP(0.8f) && Stage == 0)
 		{
 			DialogueManager.Instance.QueueMessage(this, @"It's pointless, you fools!\! You cannot dampen my positive energy!");
 			await DialogueManager.Instance.WaitForDialogue();
@@ -119,7 +119,7 @@ internal sealed class Sweetheart : Enemy
 			Stage = 1;
 		}
 		
-		if (CurrentHP < 2145 && Stage <= 1)
+		if (IsBelowHP(0.65f) && Stage <= 1)
 		{
 			DialogueManager.Instance.QueueMessage(this, "You dare raise your fists at me!?");
 			DialogueManager.Instance.QueueMessage(this, @"Fools!\! You should be grovelling on your knees!");
@@ -127,7 +127,7 @@ internal sealed class Sweetheart : Enemy
 			Stage = 2;
 		}
 		
-		if (CurrentHP < 1650 && Stage <= 2)
+		if (IsBelowHP(0.5f) && Stage <= 2)
 		{
 			UnlockEmotion();
 			DialogueManager.Instance.QueueMessage(this, @"Oho!\! My beauty and grace is boundless and everlasting...");
@@ -140,7 +140,7 @@ internal sealed class Sweetheart : Enemy
 			Stage = 3;
 		}
 		
-		if (CurrentHP < 990 && Stage <= 3)
+		if (IsBelowHP(0.3f) && Stage <= 3)
 		{
 			UnlockEmotion();
 			DialogueManager.Instance.QueueMessage(this, "Hmph! I see you are still standing.");
@@ -176,8 +176,8 @@ internal sealed class Sweetheart : Enemy
 	public override Stats GetBaseStats()
 	{
 		if (CurrentEmotion.Id is "ecstatic" or "manic")
-			return new Stats(3300, 1650, 30, 25, 40, 30, 90);
-		return new Stats(3300, 1650, 30, 25, 40, 10, 90);
+			return new Stats(3300, 1650, 30, 25, 40, 30, 90) + AdjustedStats;
+		return new Stats(3300, 1650, 30, 25, 40, 10, 90) + AdjustedStats;
 	}
 
 	public override async Task OnEndOfBattle(bool victory)

--- a/scripts/enemy/SweetheartAlt.cs
+++ b/scripts/enemy/SweetheartAlt.cs
@@ -109,7 +109,7 @@ internal sealed class SweetheartAlt : Enemy
 		if (Stage > 3)
 			return;
 		
-		if (CurrentHP < 6080 && Stage == 0)
+		if (IsBelowHP(0.8f) && Stage == 0)
 		{
 			DialogueManager.Instance.QueueMessage(this, @"It's pointless, you fools!\! You cannot dampen my positive energy!");
 			await DialogueManager.Instance.WaitForDialogue();
@@ -121,7 +121,7 @@ internal sealed class SweetheartAlt : Enemy
 			Stage = 1;
 		}
 		
-		if (CurrentHP < 4940 && Stage <= 1)
+		if (IsBelowHP(0.65f) && Stage <= 1)
 		{
 			DialogueManager.Instance.QueueMessage(this, "You dare raise your fists at me!?");
 			DialogueManager.Instance.QueueMessage(this, @"Fools!\! You should be grovelling on your knees!");
@@ -129,7 +129,7 @@ internal sealed class SweetheartAlt : Enemy
 			Stage = 2;
 		}
 		
-		if (CurrentHP < 3800 && Stage <= 2)
+		if (IsBelowHP(0.5f) && Stage <= 2)
 		{
 			UnlockEmotion();
 			DialogueManager.Instance.QueueMessage(this, @"Oho!\! My beauty and grace is boundless and everlasting...");
@@ -142,7 +142,7 @@ internal sealed class SweetheartAlt : Enemy
 			Stage = 3;
 		}
 		
-		if (CurrentHP < 2280 && Stage <= 3)
+		if (IsBelowHP(0.3f) && Stage <= 3)
 		{
 			UnlockEmotion();
 			DialogueManager.Instance.QueueMessage(this, "Hmph! I see you are still standing.");

--- a/scripts/enemy/TheEarth.cs
+++ b/scripts/enemy/TheEarth.cs
@@ -22,7 +22,7 @@ internal sealed class TheEarth : Enemy
         if (HasObserveTarget(out PartyMember observe))
             return new BattleCommand(this, observe, Skills["TEAttack"]);
         
-        if (CurrentHP < 85)
+        if (IsBelowHP(0.2f))
             return new BattleCommand(this, SelectAllTargets(), Skills["TEProtect"]);
 
         switch (CurrentEmotion.Id)

--- a/scripts/enemy/TheHooligans.cs
+++ b/scripts/enemy/TheHooligans.cs
@@ -39,7 +39,7 @@ internal sealed class TheHooligans : Enemy
     {
         if (CurrentHP <= 0) return;
 
-        if (Stage == 0 && CurrentHP < 375)
+        if (Stage == 0 && IsBelowHP(0.75f))
         {
             DialogueManager.Instance.QueueMessage("ANGEL", CenterPoint, "My master and I have been training for this moment...");
             DialogueManager.Instance.QueueMessage("THE MAVERICK", CenterPoint, "You won't make fools out of us ever again!");
@@ -49,7 +49,7 @@ internal sealed class TheHooligans : Enemy
             Stage = 1;
         }
 
-        if (Stage == 1 && CurrentHP < 250)
+        if (Stage == 1 && IsBelowHP(0.5f))
         {
             DialogueManager.Instance.QueueMessage("THE MAVERICK", CenterPoint, "ANGEL, remember our training! Make weakness your strength!");
             DialogueManager.Instance.QueueMessage("ANGEL", CenterPoint, "Yes, master![br]I won't let you down!");
@@ -57,7 +57,7 @@ internal sealed class TheHooligans : Enemy
             Stage = 2;
         }
         
-        if (Stage == 2 && CurrentHP < 125)
+        if (Stage == 2 && IsBelowHP(0.25f))
         {
             DialogueManager.Instance.QueueMessage("VANCE", CenterPoint, "KIM... are you okay?");
             DialogueManager.Instance.QueueMessage("KIM", CenterPoint, @"Huff...\! Huff...\! Heh!\! Don't worry, VANCE... I'm not done yet!");
@@ -107,7 +107,7 @@ internal sealed class TheHooligans : Enemy
 
     public override BattleCommand ProcessAI()
     {
-        if (CurrentHP <= 75)
+        if (IsBelowHP(0.152f))
             return new BattleCommand(this, SelectTargets(4), Skills["HOGroupAttack"]);
         if (Roll() < 46)
             return new BattleCommand(this, SelectTarget(), Skills["HOAngelAttack"]);

--- a/scripts/enemy/TheMaverick.cs
+++ b/scripts/enemy/TheMaverick.cs
@@ -39,7 +39,7 @@ internal sealed class TheMaverick : Enemy
     {
         if (CurrentHP <= 0) return;
 
-        if (Stage == 0 && CurrentHP < 281)
+        if (Stage == 0 && IsBelowHP(0.75f))
         {
             DialogueManager.Instance.QueueMessage(this, @"Hmph...\! Not bad...");
             DialogueManager.Instance.QueueMessage(this, "But this fight's just getting started!");
@@ -47,7 +47,7 @@ internal sealed class TheMaverick : Enemy
             Stage = 1;
         }
         
-        if (Stage == 1 && CurrentHP < 225)
+        if (Stage == 1 && IsBelowHP(0.6f))
         {
             PartyMember target = BattleManager.Instance.GetPartyMemberAtPosition(2) ?? BattleManager.Instance.GetPartyMember(0);
             DialogueManager.Instance.QueueMessage(this, "Heh, as expected of my rival!");
@@ -59,7 +59,7 @@ internal sealed class TheMaverick : Enemy
             Stage = 2;
         }
         
-        if (Stage == 2 && CurrentHP < 187)
+        if (Stage == 2 && IsBelowHP(0.499f))
         {
             DialogueManager.Instance.QueueMessage(this, "Ha! Is that all you've got!?");
             DialogueManager.Instance.QueueMessage(this, "I've only been using 10% of my power!");
@@ -68,7 +68,7 @@ internal sealed class TheMaverick : Enemy
             Stage = 3;
         }
         
-        if (Stage == 3 && CurrentHP < 150)
+        if (Stage == 3 && IsBelowHP(0.4f))
         {
             DialogueManager.Instance.QueueMessage(this, "I bet you're regretting your decision now!");
             DialogueManager.Instance.QueueMessage(this, "I'm just way too cool for you...");
@@ -77,7 +77,7 @@ internal sealed class TheMaverick : Enemy
             Stage = 4;
         }
         
-        if (Stage == 4 && CurrentHP < 112)
+        if (Stage == 4 && IsBelowHP(0.299f))
         {
             DialogueManager.Instance.QueueMessage(this, @"It's only... \!Huff...\! a matter of time before you tire yourselves out!");
             DialogueManager.Instance.QueueMessage(this, "My victory is imminent!");
@@ -85,14 +85,14 @@ internal sealed class TheMaverick : Enemy
             Stage = 5;
         }
         
-        if (Stage == 5 && CurrentHP < 75)
+        if (Stage == 5 && IsBelowHP(0.2f))
         {
             DialogueManager.Instance.QueueMessage(this, @"Huff...\! I'll admit...\! I'm impressed...\! but you're still light years away from defeating me!");
             await DialogueManager.Instance.WaitForDialogue();
             Stage = 6;
         }
         
-        if (Stage == 6 && CurrentHP < 37)
+        if (Stage == 6 && IsBelowHP(0.099f))
         {
             DialogueManager.Instance.QueueMessage(this, @"[shake rate=20]Huff...\! Huff...");
             DialogueManager.Instance.QueueMessage(this, @"No...\![br]This is impossible!\! Improbable!");

--- a/scripts/enemy/UnbreadTwins.cs
+++ b/scripts/enemy/UnbreadTwins.cs
@@ -84,7 +84,7 @@ internal sealed class UnbreadTwins : Enemy
 		if (Stage > 3)
 			return;
 
-		if (CurrentHP < 6000 && Stage == 0)
+		if (IsBelowHP(0.8f) && Stage == 0)
 		{
 			DialogueManager.Instance.QueueMessage("DOUGHIE", CenterPoint, @"[wave freq=10][br]Fresh bread...\! fresh bread...\! Every day, it's fresh bread...");
 			DialogueManager.Instance.QueueMessage("BISCUIT", CenterPoint, "[wave freq=10][br]Ohooooooooo...");
@@ -97,7 +97,7 @@ internal sealed class UnbreadTwins : Enemy
 			Stage = 1;
 		}
 
-		if (CurrentHP < 4875 && Stage <= 1)
+		if (IsBelowHP(0.65f) && Stage <= 1)
 		{
 			DialogueManager.Instance.QueueMessage("DOUGHIE", CenterPoint, @"We're doomed to bake bread for all enternity...\! aren't we, BISCUIT?");
 			DialogueManager.Instance.QueueMessage("BISCUIT", CenterPoint, "[wave freq=10]Ohooo...");
@@ -105,7 +105,7 @@ internal sealed class UnbreadTwins : Enemy
 			Stage = 2;
 		}
 
-		if (CurrentHP < 3750 && Stage <= 2)
+		if (IsBelowHP(0.5f) && Stage <= 2)
 		{
 			DialogueManager.Instance.QueueMessage("DOUGHIE", CenterPoint, "We're running out of supplies! What do we do, BISCUIT!?");
 			DialogueManager.Instance.QueueMessage("BISCUIT", CenterPoint, "[wave freq=10]Ohooooooo!");
@@ -116,7 +116,7 @@ internal sealed class UnbreadTwins : Enemy
 			Stage = 3;
 		} 
 		
-		if (CurrentHP < 1875 && Stage <= 3)
+		if (IsBelowHP(0.25f) && Stage <= 3)
 		{
 			DialogueManager.Instance.QueueMessage("DOUGHIE", CenterPoint, @"We're running low on everything!\! We have almost nothing left...");
 			DialogueManager.Instance.QueueMessage("BISCUIT", CenterPoint, "[wave freq=10]Ohooo...");

--- a/scripts/enemy/UnbreadTwinsAlt.cs
+++ b/scripts/enemy/UnbreadTwinsAlt.cs
@@ -84,7 +84,7 @@ internal sealed class UnbreadTwinsAlt : Enemy
         if (Stage > 3)
             return;
 
-        if (CurrentHP < 8000 && Stage == 0)
+        if (IsBelowHP(0.8f) && Stage == 0)
         {
             DialogueManager.Instance.QueueMessage("DOUGHIE", CenterPoint, @"[wave freq=10][br]Fresh bread...\! fresh bread...\! Every day, it's fresh bread...");
             DialogueManager.Instance.QueueMessage("BISCUIT", CenterPoint, "[wave freq=10][br]Ohooooooooo...");
@@ -97,7 +97,7 @@ internal sealed class UnbreadTwinsAlt : Enemy
             Stage = 1;
         }
 
-        if (CurrentHP < 6500 && Stage <= 1)
+        if (IsBelowHP(0.65f) && Stage <= 1)
         {
             DialogueManager.Instance.QueueMessage("DOUGHIE", CenterPoint, @"We're doomed to bake bread for all enternity...\! aren't we, BISCUIT?");
             DialogueManager.Instance.QueueMessage("BISCUIT", CenterPoint, "[wave freq=10]Ohooo...");
@@ -105,7 +105,7 @@ internal sealed class UnbreadTwinsAlt : Enemy
             Stage = 2;
         }
 
-        if (CurrentHP < 5000 && Stage <= 2)
+        if (IsBelowHP(0.5f) && Stage <= 2)
         {
             DialogueManager.Instance.QueueMessage("DOUGHIE", CenterPoint, "We're running out of supplies! What do we do, BISCUIT!?");
             DialogueManager.Instance.QueueMessage("BISCUIT", CenterPoint, "[wave freq=10]Ohooooooo!");
@@ -116,7 +116,7 @@ internal sealed class UnbreadTwinsAlt : Enemy
             Stage = 3;
         } 
         
-        if (CurrentHP < 2500 && Stage <= 3)
+        if (IsBelowHP(0.25f) && Stage <= 3)
         {
             DialogueManager.Instance.QueueMessage("DOUGHIE", CenterPoint, @"We're running low on everything!\! We have almost nothing left...");
             DialogueManager.Instance.QueueMessage("BISCUIT", CenterPoint, "[wave freq=10]Ohooo...");

--- a/scripts/enemy/Vance.cs
+++ b/scripts/enemy/Vance.cs
@@ -39,7 +39,7 @@ internal sealed class Vance : Enemy
     {
         if (CurrentHP <= 0) return;
 
-        if (!HasSpoken && CurrentHP < 72)
+        if (!HasSpoken && IsBelowHP(0.497f))
         {
             DialogueManager.Instance.QueueMessage(this, @"Ouch...\! That hurts.");
             await DialogueManager.Instance.WaitForDialogue();

--- a/scripts/menu/ItemMenu.cs
+++ b/scripts/menu/ItemMenu.cs
@@ -1,12 +1,10 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using Godot;
 using OmoriSandbox.Battle;
 
 namespace OmoriSandbox.Menu;
 
-internal partial class ItemMenu : Menu
+internal partial class ItemMenu : PagedMenu
 {
 	[Export] public AutofitLabel[] ItemLabels;
 	[Export] public Label CostText;
@@ -14,14 +12,12 @@ internal partial class ItemMenu : Menu
 	[Export] private Sprite2D PageDownSprite;
 	private readonly List<(Item, int)> Items = [];
 	private List<(Item, int)> DisplayedItems = [];
-	public int Page { get; private set; } = 0;
-	private List<Vector2I> Positions = [new(28, 52), new(200, 52), new(28, 76), new(200, 76)];
 
 	protected override Vector2 OpenPosition => new(138, 384);
 	protected override Vector2 ClosedPosition => new(138, 490);
-	
-	private Vector2I GridSize = new(2, 2);
-	private int MaxPage => Math.Max(0, (Items.Count - 3) / 2);
+
+	protected override int TotalCount => Items.Count;
+	protected override int DisplayedCount => DisplayedItems.Count;
 
 	public override void OnOpen(SelectionMemory memory)
 	{
@@ -64,7 +60,7 @@ internal partial class ItemMenu : Menu
 		Empty = Items.Count == 0;
 	}
 
-	private void UpdatePage()
+	protected override void UpdatePage()
 	{
         CostText.Text = "";
         foreach (AutofitLabel l in ItemLabels)
@@ -90,78 +86,10 @@ internal partial class ItemMenu : Menu
         if (CursorIndex >= DisplayedItems.Count)
 	        CursorIndex = DisplayedItems.Count - 1;
         UpdateCursor();
-        ShowItemInfo();
+        ShowInfo();
 	}
 
-	protected override void MoveCursor(Vector2I direction)
-	{
-		if (Empty) return;
-		if (BattleManager.Instance.Phase == BattlePhase.TargetSelection) return;
-		if (direction == Vector2.Down && Page < MaxPage && CursorIndex > 1)
-		{
-			Page++;
-			CursorIndex -= 2;
-			AudioManager.Instance.PlaySFX("SYS_move");
-			UpdatePage();
-			return;
-		}
-		if (direction == Vector2.Up && Page > 0 && CursorIndex < 2)
-		{
-			Page--;
-			CursorIndex += 2;
-			AudioManager.Instance.PlaySFX("SYS_move");
-			UpdatePage();
-			return;
-		}
-
-		int old = CursorIndex;
-		// omori menus have no wrapping
-		// pressing left or right simply increments/decrements the index
-		if (direction == Vector2.Left)
-		{
-			if (CursorIndex > 0)
-				CursorIndex--;
-			else if (Page > 0)
-			{
-				Page--;
-				CursorIndex = 3;
-				AudioManager.Instance.PlaySFX("SYS_move");
-				UpdatePage();
-				return;
-			}
-		}
-		else if (direction == Vector2.Right)
-		{
-			if (CursorIndex < DisplayedItems.Count - 1)
-				CursorIndex++;
-			else if (Page < MaxPage)
-			{
-				Page++;
-				CursorIndex = 0;
-				AudioManager.Instance.PlaySFX("SYS_move");
-				UpdatePage();
-				return;
-			}
-		}
-		else if (direction == Vector2.Up)
-		{
-			if (CursorIndex > 1)
-				CursorIndex -= 2;
-		}
-		else if (direction == Vector2.Down)
-		{
-			if (CursorIndex < 2 && DisplayedItems.Count > 2)
-				CursorIndex = Math.Min(CursorIndex + 2, DisplayedItems.Count - 1);
-		}
-		if (CursorIndex != old)
-		{
-			UpdateCursor();
-			ShowItemInfo();
-			AudioManager.Instance.PlaySFX("SYS_move");
-		}
-	}
-
-	private void ShowItemInfo()
+	protected override void ShowInfo()
 	{
 		if (Empty) return;
 		(Item, int) i = DisplayedItems[CursorIndex];

--- a/scripts/menu/PagedMenu.cs
+++ b/scripts/menu/PagedMenu.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using Godot;
+using OmoriSandbox.Battle;
+
+namespace OmoriSandbox.Menu;
+
+internal abstract partial class PagedMenu : Menu
+{
+	public int Page { get; protected set; } = 0;
+
+	protected List<Vector2I> Positions = [new(28, 52), new(200, 52), new(28, 76), new(200, 76)];
+
+	protected int MaxPage => Math.Max(0, (TotalCount - 3) / 2);
+
+	// the size of the full list of the menu
+	protected abstract int TotalCount { get; }
+	// the number of entries visible on the current page
+	protected abstract int DisplayedCount { get; }
+
+	protected abstract void UpdatePage();
+	protected abstract void ShowInfo();
+
+	protected override void MoveCursor(Vector2I direction)
+	{
+		if (Empty) return;
+		if (BattleManager.Instance.Phase == BattlePhase.TargetSelection) return;
+		// scrolling moves the view by one row while the cursor keeps its screen position
+		if (direction == Vector2.Down && Page < MaxPage && CursorIndex > 1)
+		{
+			Page++;
+			AudioManager.Instance.PlaySFX("SYS_move");
+			UpdatePage();
+			return;
+		}
+		if (direction == Vector2.Up && Page > 0 && CursorIndex < 2)
+		{
+			Page--;
+			AudioManager.Instance.PlaySFX("SYS_move");
+			UpdatePage();
+			return;
+		}
+
+		int old = CursorIndex;
+		// omori menus have no wrapping
+		// pressing left or right simply increments/decrements the index
+		if (direction == Vector2.Left)
+		{
+			if (CursorIndex > 0)
+				CursorIndex--;
+			else if (Page > 0)
+			{
+				Page--;
+				CursorIndex = 1;
+				AudioManager.Instance.PlaySFX("SYS_move");
+				UpdatePage();
+				return;
+			}
+		}
+		else if (direction == Vector2.Right)
+		{
+			if (CursorIndex < DisplayedCount - 1)
+				CursorIndex++;
+			else if (Page < MaxPage)
+			{
+				Page++;
+				CursorIndex = 2;
+				AudioManager.Instance.PlaySFX("SYS_move");
+				UpdatePage();
+				return;
+			}
+		}
+		else if (direction == Vector2.Up)
+		{
+			if (CursorIndex > 1)
+				CursorIndex -= 2;
+		}
+		else if (direction == Vector2.Down)
+		{
+			if (CursorIndex < 2 && DisplayedCount > 2)
+				CursorIndex = Math.Min(CursorIndex + 2, DisplayedCount - 1);
+		}
+		if (CursorIndex != old)
+		{
+			UpdateCursor();
+			ShowInfo();
+			AudioManager.Instance.PlaySFX("SYS_move");
+		}
+	}
+}

--- a/scripts/menu/PagedMenu.cs.uid
+++ b/scripts/menu/PagedMenu.cs.uid
@@ -1,0 +1,1 @@
+uid://c4wg5e4s8hykl

--- a/scripts/menu/SkillMenu.cs
+++ b/scripts/menu/SkillMenu.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Godot;
@@ -7,7 +6,7 @@ using OmoriSandbox.Battle;
 
 namespace OmoriSandbox.Menu;
 
-internal partial class SkillMenu : Menu
+internal partial class SkillMenu : PagedMenu
 {
 	[Export] public AutofitLabel[] SkillLabels;
 	[Export] public Label CostText;
@@ -15,15 +14,14 @@ internal partial class SkillMenu : Menu
 	[Export] private Sprite2D PageDownSprite;
 	private readonly List<Skill> Skills = [];
 	private List<Skill> DisplayedSkills = [];
-	public int Page { get; private set; } = 0;
-	private List<Vector2I> Positions = [new(28, 52), new(200, 52), new(28, 76), new(200, 76)];
 
 	private PartyMember Actor;
 
 	protected override Vector2 OpenPosition => new(138, 384);
 	protected override Vector2 ClosedPosition => new(138, 490);
 
-	private int MaxPage => Math.Max(0, (Skills.Count - 3) / 2);
+	protected override int TotalCount => Skills.Count;
+	protected override int DisplayedCount => DisplayedSkills.Count;
 
 	public override void OnOpen(SelectionMemory memory)
 	{
@@ -67,7 +65,7 @@ internal partial class SkillMenu : Menu
 		Empty = Skills.Count == 0;
 	}
 
-	private void UpdatePage()
+	protected override void UpdatePage()
 	{
 		CostText.Text = "0";
 		foreach (AutofitLabel l in SkillLabels)
@@ -98,83 +96,15 @@ internal partial class SkillMenu : Menu
 		if (CursorIndex >= DisplayedSkills.Count)
 			CursorIndex = DisplayedSkills.Count - 1;
 		UpdateCursor();
-		ShowSkillInfo();
+		ShowInfo();
 	}
 
-	private void ShowSkillInfo()
+	protected override void ShowInfo()
 	{
 		if (Empty) return;
 		Skill s = DisplayedSkills[CursorIndex];
 		CostText.Text = s.Cost(Actor).ToString();
 		BattleLogManager.Instance.ClearAndShowMessage($"[font_size=28]{s.Name}\n[font_size=20]{s.Description.Replace("[actor]", Actor.Name.ToUpper()).Replace("[first]", BattleManager.Instance.GetPartyMember(0).Name.ToUpper())}");
-	}
-
-	protected override void MoveCursor(Vector2I direction)
-	{
-		if (Empty) return;
-		if (BattleManager.Instance.Phase == BattlePhase.TargetSelection) return;
-		if (direction == Vector2.Down && Page < MaxPage && CursorIndex > 1)
-		{
-			Page++;
-			CursorIndex -= 2;
-			AudioManager.Instance.PlaySFX("SYS_move");
-			UpdatePage();
-			return;
-		}
-		if (direction == Vector2.Up && Page > 0 && CursorIndex < 2)
-		{
-			Page--;
-			CursorIndex += 2;
-			AudioManager.Instance.PlaySFX("SYS_move");
-			UpdatePage();
-			return;
-		}
-
-		int old = CursorIndex;
-		// omori menus have no wrapping
-		// pressing left or right simply increments/decrements the index
-		if (direction == Vector2.Left)
-		{
-			if (CursorIndex > 0)
-				CursorIndex--;
-			else if (Page > 0)
-			{
-				Page--;
-				CursorIndex = 3;
-				AudioManager.Instance.PlaySFX("SYS_move");
-				UpdatePage();
-				return;
-			}
-		}
-		else if (direction == Vector2.Right)
-		{
-			if (CursorIndex < DisplayedSkills.Count - 1)
-				CursorIndex++;
-			else if (Page < MaxPage)
-			{
-				Page++;
-				CursorIndex = 0;
-				AudioManager.Instance.PlaySFX("SYS_move");
-				UpdatePage();
-				return;
-			}
-		}
-		else if (direction == Vector2.Up)
-		{
-			if (CursorIndex > 1)
-				CursorIndex -= 2;
-		}
-		else if (direction == Vector2.Down)
-		{
-			if (CursorIndex < 2 && DisplayedSkills.Count > 2)
-				CursorIndex = Math.Min(CursorIndex + 2, DisplayedSkills.Count - 1);
-		}
-		if (CursorIndex != old)
-		{
-			UpdateCursor();
-			ShowSkillInfo();
-			AudioManager.Instance.PlaySFX("SYS_move");
-		}
 	}
 
 	protected override void OnSelect()

--- a/scripts/party/PartyMember.cs
+++ b/scripts/party/PartyMember.cs
@@ -124,7 +124,7 @@ public abstract class PartyMember : Actor
 	/// The party member's base stats, plus any stats given by a <see cref="Battle.Weapon"/> and/or <see cref="Equipment"/>.
 	/// </summary>
 	/// <returns></returns>
-	protected override Stats GetBaseStats()
+	public override Stats GetBaseStats()
 	{
 		Stats stats = BaseStats;
 		Weapon.Apply(ref stats);


### PR DESCRIPTION
## Changelog
### For Players
- Added the Evasion (EVA) stat from RPGMaker, mainly for modding. All vanilla enemies and party members have an EVA stat of 0 by default
- Added the EVA stat to More Info
- Added a 'Combined Accuracy Formula' global setting. If enabled, a miss is calculated by `(user.HIT - target.EVA)` instead of separate checks, commonly found in OMORI mods that utilize Evasion
- Enemies now have a Stat Adjustment Editor in the Editor
- Added a 'Dialogue Speed' global setting, ranging from 0.25x speed to Instant speed
   -  Waits and input waits are still respected as normal even at Instant speed
- Added a 'Combined Buffs/Debuffs' preset setting. When enabled, tiered stat modifiers (like ATK, DEF, etc.) will be treated as a single state, and buffing/debuffing the state will raise/lower the state accordingly
- UI elements will now dim whenever dialogue is on screen
- Removed unused dialogue from Sir Maximus II and III
- Added the ghosts to Sir Maximus II and III's ultimate attack
- Fixed the enemy list in the Editor not defaulting to the currently selected enemy
- Fixed the FPS/Watermark display not displaying correctly when launching the game with Show FPS disabled
- Fixed scrollable menus not moving the cursor properly between pages
- Fixed the battlelog not displaying the oldest and newest message properly when full
- Fixed the actor battle memory sometimes not properly remembering the last selected action
- Fixed Afraid not displaying a moving attack
- Fixed Slime Girls' Throw Everything attack happening during the turn instead of at the end of the turn
- Fixed the Infinite Buffs/Debuffs setting not working at all
- Fixed queuing a restart during end of turn dialogue causing unintended behavior
### For Modders
Due to the addition of the EVA stat, you will need to recompile your mods to reflect these signature changes.

- As mentioned prior, all actors now have an Evasion (EVA) stat
- Added events for when a stat modifier is added/removed from an actor (OnStatModifierAdded and OnStatModifierRemoved)
- Added an event for when the battle is exited, alongside a Reason parameter
   - This event should be utilized to perform any post-battle cleanup necessary by your mod
- Damage reduced into the negatives by a StatModifier will now be considered a miss
   -  Damage reduced to zero will continue as normal
- Custom TierStatModifiers now have a .WithCounterpart(string) method for specifying a counterpart (opposite) state, used when 'Combined Buffs/Debuffs' is enabled 
- If a turn count is not specified during registering, TierStatModifiers now default to infinite turns instead of 6 turns
- Added a IsBelowHP(float) method for performing battle condition checks that respect enemy Max HP changes
- Fixed the GetBaseStats() Actor method being protected instead of public
- Fixed the OnStartOfTurn() StatModifier method not running for enemies
- Fixed Max HP/Max Juice stat modifiers not working correctly